### PR TITLE
Fix for KafkaConnectorAssembler for Eclipse IDE.

### DIFF
--- a/jena-kafka-client/src/main/java/org/apache/jena/kafka/cmd/FK_DumpTopic.java
+++ b/jena-kafka-client/src/main/java/org/apache/jena/kafka/cmd/FK_DumpTopic.java
@@ -33,7 +33,6 @@ import org.apache.jena.cmd.ArgDecl;
 import org.apache.jena.cmd.CmdException;
 import org.apache.jena.cmd.CmdGeneral;
 import org.apache.jena.kafka.common.DataState;
-import org.apache.jena.riot.RIOT;
 import org.apache.jena.sys.JenaSystem;
 import org.apache.kafka.clients.consumer.*;
 import org.apache.kafka.clients.producer.Producer;
@@ -54,7 +53,6 @@ public class FK_DumpTopic extends CmdGeneral {
     static {
         LogCtl.setLog4j2();
         JenaSystem.init();
-        RIOT.getContext().set(RIOT.symTurtleDirectiveStyle, "sparql");
     }
 
     public static void main(String...args) {

--- a/jena-kafka-client/src/main/java/org/apache/jena/kafka/cmd/FK_DumpTopic2.java
+++ b/jena-kafka-client/src/main/java/org/apache/jena/kafka/cmd/FK_DumpTopic2.java
@@ -27,7 +27,6 @@ import org.apache.jena.kafka.KConnectorDesc;
 import org.apache.jena.kafka.KafkaConnectorAssembler;
 import org.apache.jena.kafka.common.DataState;
 import org.apache.jena.kafka.common.DeserializerDump;
-import org.apache.jena.riot.RIOT;
 import org.apache.jena.sparql.core.assembler.AssemblerUtils;
 import org.apache.jena.sys.JenaSystem;
 import org.apache.kafka.clients.consumer.Consumer;
@@ -44,13 +43,11 @@ public class FK_DumpTopic2 {
     static {
         LogCtl.setLog4j2();
         JenaSystem.init();
-        RIOT.getContext().set(RIOT.symTurtleDirectiveStyle, "sparql");
     }
 
     public static void main(String... args) {
         // No args - assumes FK_Defaults.connectorFile
         LogCtl.setLog4j2();
-        RIOT.getContext().set(RIOT.symTurtleDirectiveStyle, "sparql");
 
         AssemblerUtils.registerAssembler(null, KafkaConnectorAssembler.getType(), new KafkaConnectorAssembler());
         KConnectorDesc conn = (KConnectorDesc)AssemblerUtils.build(FK_Defaults.connectorFile, KafkaConnectorAssembler.getType());

--- a/jena-kafka-client/src/main/java/org/apache/jena/kafka/cmd/FK_Send.java
+++ b/jena-kafka-client/src/main/java/org/apache/jena/kafka/cmd/FK_Send.java
@@ -32,7 +32,6 @@ import org.apache.jena.cmd.CmdException;
 import org.apache.jena.cmd.CmdGeneral;
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFLanguages;
-import org.apache.jena.riot.RIOT;
 import org.apache.jena.riot.WebContent;
 import org.apache.jena.riot.web.HttpNames;
 import org.apache.jena.sys.JenaSystem;
@@ -56,7 +55,6 @@ public class FK_Send extends CmdGeneral {
     static {
         LogCtl.setLog4j2();
         JenaSystem.init();
-        RIOT.getContext().set(RIOT.symTurtleDirectiveStyle, "sparql");
     }
 
     public static void main(String... args) {

--- a/jena-kafka-client/src/main/java/org/apache/jena/kafka/cmd/FK_SyncDB.java
+++ b/jena-kafka-client/src/main/java/org/apache/jena/kafka/cmd/FK_SyncDB.java
@@ -26,7 +26,6 @@ import org.apache.jena.kafka.KafkaConnectorAssembler;
 import org.apache.jena.kafka.RequestFK;
 import org.apache.jena.kafka.common.DataState;
 import org.apache.jena.kafka.common.PersistentState;
-import org.apache.jena.riot.RIOT;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.assembler.AssemblerUtils;
 import org.apache.jena.sys.JenaSystem;
@@ -45,7 +44,6 @@ public class FK_SyncDB {
     static {
         LogCtl.setLog4j2();
         JenaSystem.init();
-        RIOT.getContext().set(RIOT.symTurtleDirectiveStyle, "sparql");
     }
     public static void main(String... args) {
         // No args - assumes FK_Defaults.connectorFile

--- a/jena-kafka-connector/src/main/java/org/apache/jena/kafka/KafkaConnectorAssembler.java
+++ b/jena-kafka-connector/src/main/java/org/apache/jena/kafka/KafkaConnectorAssembler.java
@@ -18,7 +18,6 @@ package org.apache.jena.kafka;
 
 import static org.apache.jena.kafka.Assem2.onError;
 
-import java.io.PrintStream;
 import java.util.List;
 import java.util.Properties;
 import java.util.UUID;
@@ -30,7 +29,6 @@ import org.apache.jena.assembler.Mode;
 import org.apache.jena.assembler.assemblers.AssemblerBase;
 import org.apache.jena.atlas.lib.IRILib;
 import org.apache.jena.atlas.lib.StrUtils;
-import org.apache.jena.atlas.logging.Log;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
@@ -120,7 +118,7 @@ public class KafkaConnectorAssembler extends AssemblerBase implements Assembler 
     public static Node pKafkaBootstrapServers = NodeFactory.createURI(NS+"bootstrapServers");
     public static Node pKafkaGroupId          = NodeFactory.createURI(NS+"groupId");
 
-    // Values.
+    // Default values.
     private static boolean dftSyncTopic       = true;
     private static boolean dftReplayTopic     = false;
     public static String dftKafkaGroupId      = "JenaFusekiKafka";
@@ -201,22 +199,6 @@ public class KafkaConnectorAssembler extends AssemblerBase implements Assembler 
         boolean syncTopic = Assem2.getBooleanOrDft(graph, node, pSyncTopic, dftSyncTopic, errorException);
         boolean replayTopic = Assem2.getBooleanOrDft(graph, node, pReplayTopic, dftReplayTopic, errorException);
 
-        String eventSource = Assem2.getStringOrDft(graph, node, pEventSource, null, errorException);
-        if ( eventSource != null )
-            Log.warn(this, "Event source not supported");
-
-        String logDestination = Assem2.getStringOrDft(graph, node, pEventLog, null, errorException);
-        boolean verbose = logDestination != null;
-        @SuppressWarnings("resource")
-        PrintStream logOutput =
-                logDestination == null ? null :
-                    switch(logDestination) {
-                            case "", "stdout" -> System.out;
-                            case "stderr" -> System.err;
-                            // For now - later, filename base.
-                            default -> null;
-                    };
-
         String stateFile = Assem2.getAsString(graph, node, pStateFile, errorException);
         // The file name can be a relative file name as a string or a
         // file: can URL place the area next to the configuration file.
@@ -232,8 +214,8 @@ public class KafkaConnectorAssembler extends AssemblerBase implements Assembler 
         // ----
         Properties kafkaConsumerProps = kafkaConsumerProps(graph,  node,  topic, bootstrapServers, groupId);
         return new KConnectorDesc(topic, bootstrapServers,
-                                       datasetName, remoteEndpoint, stateFile, syncTopic,
-                                       replayTopic, kafkaConsumerProps);
+                                  datasetName, remoteEndpoint, stateFile, syncTopic,
+                                  replayTopic, kafkaConsumerProps);
     }
 
     private Properties kafkaConsumerProps(Graph graph, Node node,

--- a/jena-kafka-connector/src/main/java/org/apache/jena/kafka/KafkaConnectorAssembler.java
+++ b/jena-kafka-connector/src/main/java/org/apache/jena/kafka/KafkaConnectorAssembler.java
@@ -338,4 +338,3 @@ public class KafkaConnectorAssembler extends AssemblerBase implements Assembler 
         return datasetPath;
     }
 }
-


### PR DESCRIPTION
Fix for `KafkaConnectorAssembler` -- code caused an Eclipse compiler NPE.
This was not affecting the maven build.

Some clearup.

