### PR TITLE
Clean dependencies

### DIFF
--- a/jena-fuseki-kafka-module/pom.xml
+++ b/jena-fuseki-kafka-module/pom.xml
@@ -46,29 +46,7 @@
     <dependency>
       <groupId>org.apache.jena</groupId>
       <artifactId>jena-fuseki-main</artifactId>    
-      <exclusions>
-        <exclusion>
-          <!-- Prefer the version coming via Jetty -->
-          <groupId>jakarta.servlet</groupId>
-          <artifactId>jakarta.servlet-api</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency> 
-
-    <!-- Temporary. 
-      Choose the version coming via Jetty12/ee10
-      This is only necessary because Fuseki has
-        org.apache.commons:commons-fileupload2-jakarta (2.0.0-M1)
-       and not
-        org.apache.commons:commons-fileupload2-jakarta-servlet6 (2.0.0-M2)
-      When Fuseki gets sorted out and releasesd (Jena5.0.0), this can go away.
-    -->
-    <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-      <version>6.0.0</version>
-    </dependency>
-
 
     <dependency>
       <groupId>org.junit.platform</groupId>

--- a/jena-fuseki-kafka-module/src/main/java/org/apache/jena/fuseki/kafka/lib/HttpServletResponseMinimal.java
+++ b/jena-fuseki-kafka-module/src/main/java/org/apache/jena/fuseki/kafka/lib/HttpServletResponseMinimal.java
@@ -28,7 +28,6 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import org.apache.jena.riot.WebContent;
 import org.apache.jena.riot.web.HttpNames;
-import org.apache.jena.web.HttpSC;
 
 public class HttpServletResponseMinimal implements HttpServletResponse {
 
@@ -96,11 +95,23 @@ public class HttpServletResponseMinimal implements HttpServletResponse {
         hasCommitted = true;
     }
 
+    // At jakarta.servlet-api v6.1.0 this can be deleted
+    // and the next method have the @Override uncommented.
     @Override
     public void sendRedirect(String location) {
         if ( hasCommitted )
             throw new IllegalStateException();
-        setStatus(HttpSC.FOUND_302);
+        setStatus(HttpServletResponse.SC_FOUND);
+        setHeader(HttpNames.hLocation, location);
+        hasCommitted = true;
+    }
+
+    // At jakarta.servlet-api v6.1.0 this will be needed
+    //@Override
+    public void sendRedirect(String location, int sc, boolean clearBuffer) throws IOException {
+        if ( hasCommitted )
+            throw new IllegalStateException();
+        setStatus(sc);
         setHeader(HttpNames.hLocation, location);
         hasCommitted = true;
     }

--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,15 @@
         <groupId>org.apache.jena</groupId>
         <artifactId>jena-arq</artifactId>
         <version>${ver.jena}</version>
+        <!-- 
+             Exclusions for checkerframework and errorprone can be
+             removed for Jena 5.1.0 because Jena does not pass them on.
+        -->
         <exclusions>
+          <exclusion>
+            <groupId>org.checkerframework</groupId>
+            <artifactId>checker-qual</artifactId>
+          </exclusion>
           <exclusion>
             <groupId>com.google.errorprone</groupId>
             <artifactId>error_prone_annotations</artifactId>


### PR DESCRIPTION
1. Don't directly depend on jakarta-servlet-api now jena 5.0.0 is a dependency.
1. Don't pull in `checkerframework` (minor) to avoid downstream potential problems with dependency convergence.