### PR TITLE
Increase Kafka polling durations (CORE-399)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Kafka Connector for Apache Jena Fuseki
 
+## 1.3.4
+
+- Changed Kafka polling durations to be consistenly longer to avoid processing too small batches when the consumer is
+  caught up with the producer
+- Upgraded various test and build dependencies to latest available
+
 ## 1.3.3
 
 - Apache Jena upgraded to 5.1.0

--- a/jena-fuseki-kafka-module/src/main/java/org/apache/jena/fuseki/kafka/FKBatchProcessor.java
+++ b/jena-fuseki-kafka-module/src/main/java/org/apache/jena/fuseki/kafka/FKBatchProcessor.java
@@ -97,8 +97,6 @@ public class FKBatchProcessor {
                 dataState.setLastOffset(newOffset);
                 commitedState = newOffset;
                 rtn = true;
-                // Switch to shorter polling wait
-                pollingDuration = FKConst.pollingWaitDurationMore;
             }
             if ( LOG.isDebugEnabled() )
                 FmtLog.debug(LOG, "[%s] Exit receiver loop at i=%d", topic, i);

--- a/jena-fuseki-kafka-module/src/main/java/org/apache/jena/fuseki/kafka/FKConst.java
+++ b/jena-fuseki-kafka-module/src/main/java/org/apache/jena/fuseki/kafka/FKConst.java
@@ -28,26 +28,10 @@ public class FKConst {
     public static final Duration checkKafkaDuration = Duration.ofMillis(500);
 
     /**
-     * Time to wait during the initial sync from the topic during connector startup.
-     * This is a quick sync for immediate (synchronous) catch-up during connector
-     * setup. A large amount of catch is done asynchronously during the first time
-     * round the polling loop.
-     * See {@link FKS#addConnectorToServer} and {@link FKS#oneTopicPoll}.
-     */
-    public static final Duration initialWaitDuration = Duration.ofMillis(500);
-
-    /**
      * Length of the wait when polling Kafka regularly.
      * See {@link FKS#topicPoll}.
      */
     public static final Duration pollingWaitDuration = Duration.ofMillis(10_000);
-
-    /**
-     * Length of the wait when polling Kafka after having received some data.
-     * This is the loop in {@link FKBatchProcessor#receiverStep}.
-     * See {@link FKS#topicPoll}.
-     */
-    public static final Duration pollingWaitDurationMore = Duration.ofMillis(10);
 
     /**
      * Kafka has a default message of 500 for consumer.poll

--- a/jena-fuseki-kafka-module/src/main/java/org/apache/jena/fuseki/kafka/FKS.java
+++ b/jena-fuseki-kafka-module/src/main/java/org/apache/jena/fuseki/kafka/FKS.java
@@ -102,7 +102,7 @@ public class FKS {
             FmtLog.info(LOG, "[%s] Start FusekiKafka : Topic = %s : Relay = %s", topicName, topicName, conn.getRemoteEndpoint());
 
         // Do now for some catchup.
-        oneTopicPoll(batchProcessor, consumer, dataState, FKConst.initialWaitDuration);
+        oneTopicPoll(batchProcessor, consumer, dataState, FKConst.pollingWaitDuration);
 
         FmtLog.info(LOG, "[%s] Initial sync : Offset = %d", topicName, dataState.getLastOffset());
 

--- a/jena-fuseki-kafka-module/src/test/java/org/apache/jena/fuseki/kafka/DockerTestFK.java
+++ b/jena-fuseki-kafka-module/src/test/java/org/apache/jena/fuseki/kafka/DockerTestFK.java
@@ -146,8 +146,8 @@ public class DockerTestFK {
                 //.verbose(true)
                 .add(DSG,  dsg)
                 .build();
-        KConnectorDesc conn = new KConnectorDesc(TOPIC, null/*bootStrapservers*/, DSG, null/*remoteEndpoint*/, null/*stateFile*/,
-                                                           false/*syncTopic*/, true/*replayTopic*/,
+        KConnectorDesc conn = new KConnectorDesc(TOPIC, null, DSG, null, null,
+                                                           false, true,
                                                            consumerProps);
         // Manual call to setup the server.
         FKBatchProcessor batchProcessor = FKS.plainFKBatchProcessor(conn, server.getServletContext());


### PR DESCRIPTION
Removes very short duration polls because contrary to assumption they don't help with catching up faster, and may result in very small batches being processed if the consumer is caught up with the producer.  Using a longer poll is always safe as Kafka will return ASAP when the poll event limit/total message size limit is reached which will be fairly immediate when the consumer is lagging behind the producer.