### PR TITLE
[CORE-390] Improve message batching when polling kafka

### DIFF
--- a/jena-fuseki-kafka-module/pom.xml
+++ b/jena-fuseki-kafka-module/pom.xml
@@ -28,7 +28,7 @@
     <groupId>io.telicent.jena</groupId>
     <artifactId>jena-kafka</artifactId>
     <version>1.3.5-SNAPSHOT</version>
-    <relativePath>..</relativePath>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <properties>
@@ -82,6 +82,12 @@
           <artifactId>commons-compress</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
     </dependency>
 
   </dependencies>

--- a/jena-fuseki-kafka-module/src/main/java/org/apache/jena/fuseki/kafka/FKBatchProcessor.java
+++ b/jena-fuseki-kafka-module/src/main/java/org/apache/jena/fuseki/kafka/FKBatchProcessor.java
@@ -219,7 +219,7 @@ public class FKBatchProcessor {
             // No transactional set. Assume the fkProcessor.process knows what it is doing.
             return execBatch(recordList);
         }
-        return transactional.calculate(()->execBatch(recordList));
+        return transactional.calculateWrite(()->execBatch(recordList));
     }
 
     private void batchFinish(String topic, long lastOffsetState, long newOffsetState, Timer timer) {

--- a/jena-fuseki-kafka-module/src/main/java/org/apache/jena/fuseki/kafka/FKBatchProcessor.java
+++ b/jena-fuseki-kafka-module/src/main/java/org/apache/jena/fuseki/kafka/FKBatchProcessor.java
@@ -17,6 +17,8 @@
 package org.apache.jena.fuseki.kafka;
 
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 import org.apache.jena.atlas.lib.Timer;
@@ -31,6 +33,8 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.slf4j.Logger;
 
+import static org.apache.jena.kafka.SysJenaKafka.*;
+
 /**
  * The engine for the Kafka-Fuseki connector.
  * <p>
@@ -38,7 +42,7 @@ import org.slf4j.Logger;
  */
 public class FKBatchProcessor {
 
-    private static Logger LOG = FusekiKafka.LOG;
+    private static final Logger LOG = FusekiKafka.LOG;
 
     /**
      * A batch processor that applies a FKProcessor fkProcessor.
@@ -110,26 +114,75 @@ public class FKBatchProcessor {
 
     private static final boolean VERBOSE = true;
 
+    public static int MIN_BATCH_CHECK_THRESHOLD = 25;
+
+
     /** Do one Kafka consumer poll step. */
     private long receiverStep(String topic, long lastOffsetState, Consumer<String, RequestFK> consumer, Duration pollingDuration) {
         Objects.requireNonNull(pollingDuration);
         Objects.requireNonNull(consumer);
         if ( LOG.isDebugEnabled() )
             FmtLog.debug(LOG, "[%s] consumer.poll(%s ms)", topic, pollingDuration.toMillis());
-        ConsumerRecords<String, RequestFK> cRecords = consumer.poll(pollingDuration);
-        return processBatch(topic, lastOffsetState, cRecords);
+        List<ConsumerRecords<String,RequestFK>> recordList = consumeMessages(consumer, pollingDuration);
+        return processBatch(topic, lastOffsetState, recordList);
     }
 
-    public long processBatch(String topic, long lastOffsetState, ConsumerRecords<String, RequestFK> cRecords) {
-        if ( cRecords.isEmpty() )
+    /**
+     * Poll Kafka - if results are beneath min batching thresholds, poll again
+     * until we do or receive an empty return set.
+     *
+     * @param consumer Kafka Consumer
+     * @param pollingDuration how long to take pulling
+     * @return a List of Consumer Records retrieved from Kafka.
+     */
+    private List<ConsumerRecords<String, RequestFK>> consumeMessages(Consumer<String, RequestFK> consumer, Duration pollingDuration) {
+        List<ConsumerRecords<String,RequestFK>> recordList = new ArrayList<>();
+        ConsumerRecords<String, RequestFK> cRecords = consumer.poll(pollingDuration);
+        recordList.add(cRecords);
+        int totalRecordCountSoFar = cRecords.count();
+        long totalPayloadSizeSoFar = payloadSize(cRecords);
+        while (shouldProcessMoreForBatch(cRecords, totalRecordCountSoFar, totalPayloadSizeSoFar)) {
+            cRecords = consumer.poll(pollingDuration);
+            recordList.add(cRecords);
+            totalRecordCountSoFar += cRecords.count();
+            totalPayloadSizeSoFar += payloadSize(cRecords);
+        }
+        return recordList;
+    }
+
+    /**
+     * Checks whether we should continue checking kafka for messages.
+     * This is to avoid out-pacing the feeds and inefficiently reading
+     * 1-2 messages at a time. By polling again we can build a more
+     * efficient batch of records to process.
+     *
+     * @param currentRecords latest records polled from Kafka
+     * @param totalCountSoFar count of records acquired so far
+     * @param totalPayloadSizeSoFar size of payload acquired so far
+     * @return true to continue reading from kafka, false to continue processing.
+     */
+    private boolean shouldProcessMoreForBatch(ConsumerRecords<String, RequestFK> currentRecords, int totalCountSoFar, long totalPayloadSizeSoFar) {
+        return !currentRecords.isEmpty()
+                && currentRecords.count() < MIN_BATCH_CHECK_THRESHOLD
+                && totalCountSoFar < KAFKA_FETCH_POLL_SIZE
+                && totalPayloadSizeSoFar < KAFKA_FETCH_BYTE_SIZE;
+    }
+
+    public long processBatch(String topic, long lastOffsetState, List<ConsumerRecords<String,RequestFK>> recordList) {
+        if (recordList.isEmpty() || recordList.get(0).isEmpty() ) {
             // Nothing received - no change.
             return lastOffsetState;
+        }
+        int count = 0;
+        long payloadSize = 0L;
+        for (ConsumerRecords<String, RequestFK> cRecords : recordList) {
+            count += cRecords.count();
+            payloadSize += payloadSize(cRecords);
+        }
 
-        int count = cRecords.count();
-        long payloadSize = payloadSize(cRecords);
         Timer timer = batchStart(topic, lastOffsetState, count, payloadSize);
 
-        long newOffset = batchProcess(topic, cRecords);
+        long newOffset = batchProcess(topic, recordList);
 
         // Check expectation.
         long newOffset2 = lastOffsetState + count;
@@ -161,12 +214,12 @@ public class FKBatchProcessor {
         return timer;
     }
 
-    private long batchProcess(String topic, ConsumerRecords<String, RequestFK> cRecords) {
+    private long batchProcess(String topic, List<ConsumerRecords<String,RequestFK>> recordList) {
         if ( transactional == null ) {
             // No transactional set. Assume the fkProcessor.process knows what it is doing.
-            return execBatch(cRecords);
+            return execBatch(recordList);
         }
-        return transactional.calculate(()->execBatch(cRecords));
+        return transactional.calculate(()->execBatch(recordList));
     }
 
     private void batchFinish(String topic, long lastOffsetState, long newOffsetState, Timer timer) {
@@ -182,21 +235,23 @@ public class FKBatchProcessor {
     }
 
     /** Execute a batch - return the new last seen offset. */
-    private long execBatch(ConsumerRecords<String, RequestFK> cRecords) {
+    private long execBatch(List<ConsumerRecords<String, RequestFK>> recordList) {
         long lastOffset = -1;
-        for ( ConsumerRecord<String, RequestFK> cRec : cRecords ) {
-            RequestFK requestFK = cRec.value();
-            if ( LOG.isDebugEnabled() )
-                FmtLog.debug(LOG, "[%s] Record Offset %s", requestFK.getTopic(), cRec.offset());
-            try {
-                fkProcessor.process(requestFK);
-                lastOffset = cRec.offset();
-            } catch(Throwable ex) {
-                // Something unexpected went wrong.
-                // Polling is asynchronous to the server.
-                // When shutting down, various things can go wrong.
-                // Log and ignore!
-                FmtLog.warn(LOG, ex, "Exception in processing: %s", ex.getMessage());
+        for(ConsumerRecords<String, RequestFK> cRecords : recordList) {
+            for (ConsumerRecord<String, RequestFK> cRec : cRecords) {
+                RequestFK requestFK = cRec.value();
+                if (LOG.isDebugEnabled())
+                    FmtLog.debug(LOG, "[%s] Record Offset %s", requestFK.getTopic(), cRec.offset());
+                try {
+                    fkProcessor.process(requestFK);
+                    lastOffset = cRec.offset();
+                } catch (Throwable ex) {
+                    // Something unexpected went wrong.
+                    // Polling is asynchronous to the server.
+                    // When shutting down, various things can go wrong.
+                    // Log and ignore!
+                    FmtLog.warn(LOG, ex, "Exception in processing: %s", ex.getMessage());
+                }
             }
         }
         return lastOffset;

--- a/jena-fuseki-kafka-module/src/test/java/org/apache/jena/fuseki/kafka/TestBatchProcessor.java
+++ b/jena-fuseki-kafka-module/src/test/java/org/apache/jena/fuseki/kafka/TestBatchProcessor.java
@@ -1,0 +1,177 @@
+package org.apache.jena.fuseki.kafka;
+
+import org.apache.jena.kafka.RequestFK;
+import org.apache.jena.kafka.common.DataState;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.jena.fuseki.kafka.FKBatchProcessor.createBatchProcessor;
+import static org.apache.jena.fuseki.kafka.FKBatchProcessor.MIN_BATCH_CHECK_THRESHOLD;
+import static org.apache.jena.kafka.SysJenaKafka.KAFKA_FETCH_POLL_SIZE;
+import static org.apache.jena.kafka.SysJenaKafka.KAFKA_FETCH_BYTE_SIZE;
+import static org.apache.jena.kafka.common.DataState.createEphemeral;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+public class TestBatchProcessor {
+
+    private final static String TOPIC = "test-topic";
+    @SuppressWarnings("unchecked")
+    private final static Consumer<String, RequestFK> consumerMock = mock(Consumer.class);
+    private final static FKProcessor mockProcessor = mock(FKProcessor.class);
+    private final static FKBatchProcessor processor = createBatchProcessor(mockProcessor);
+    private final static ConsumerRecords<String, RequestFK> emptyRecords = new ConsumerRecords<>(Collections.emptyMap());
+    private final static int ORIGINAL_POLL_SIZE = KAFKA_FETCH_POLL_SIZE;
+    private final static int ORIGINAL_BYTE_SIZE = KAFKA_FETCH_BYTE_SIZE;
+    private final static int ORIGINAL_MIN_CHECK = MIN_BATCH_CHECK_THRESHOLD;
+
+
+    @AfterEach
+    public void cleanup() {
+        reset(consumerMock, mockProcessor);
+        KAFKA_FETCH_POLL_SIZE = ORIGINAL_POLL_SIZE;
+        KAFKA_FETCH_BYTE_SIZE = ORIGINAL_BYTE_SIZE;
+        MIN_BATCH_CHECK_THRESHOLD = ORIGINAL_MIN_CHECK;
+    }
+    /**
+     * In this test we illustrate the scenario whereby we poll kafka and get nothing back.
+     * There is obviously no point polling kafka again and so continue as normal.
+     */
+    @Test
+    public void test_empty_messages() {
+        // given
+        when(consumerMock.poll(any())).thenReturn(emptyRecords);
+
+        // when
+        boolean result = processor.receiver(consumerMock, createEphemeral(TOPIC), Duration.ofMillis(1));
+
+        //then
+        assertFalse(result);
+        verify(consumerMock, times(1)).poll(any());
+        verifyNoInteractions(mockProcessor);
+    }
+
+    /**
+     * In this we test the case where a single message comes in.
+     * Our batching will poll Kafka again, due to a single record falling
+     * beneath the min batch threshold (MIN_BATCH_CHECK_THRESHOLD).
+     * Our subsequent kafka poll returns an empty result. So this is a single
+     * isolated updated. We then process it as normal.
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    public void test_simple_case_single_message() {
+        // given
+        ConsumerRecords<String, RequestFK> cRecords = generateConsumerRecords(1);
+        when(consumerMock.poll(any())).thenReturn(cRecords,emptyRecords);
+
+        // when
+        boolean result = processor.receiver(consumerMock, createEphemeral(TOPIC), Duration.ofMillis(1));
+
+        //then
+        assertTrue(result);
+        verify(mockProcessor).startBatch(anyInt(),anyLong());
+        verify(mockProcessor).process(any());
+        verify(mockProcessor).finishBatch(anyInt(),anyLong(),anyLong());
+    }
+
+
+    /**
+     * In this test, we receive a batch of messages in a single poll that are
+     * above the batch threshold, and so we do not poll kafka again, processing
+     * as normal.
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    public void test_simple_case_multiple_messages_above_threshold() {
+        // given
+        MIN_BATCH_CHECK_THRESHOLD = 5; // Reducing threshold for purposes of test.
+        int RECORD_COUNT = 6; // Just above threshold
+        ConsumerRecords<String, RequestFK> cRecords = generateConsumerRecords(RECORD_COUNT);
+        when(consumerMock.poll(any())).thenReturn(cRecords,emptyRecords);
+
+        // when
+        boolean result = processor.receiver(consumerMock, createEphemeral(TOPIC), Duration.ofMillis(1));
+
+        //then
+        assertTrue(result);
+        verify(mockProcessor).startBatch(anyInt(),anyLong());
+        verify(mockProcessor, times(6)).process(any());// 1 message of 6 records
+        verify(mockProcessor).finishBatch(anyInt(),anyLong(),anyLong());
+    }
+
+
+    /**
+     * In this test, we replicate an ongoing update whereby messages come in
+     * constantly in small amounts. We will then batch the message till we
+     * trip one of the limits, in this case the records size (KAFKA_FETCH_POLL_SIZE).
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    public void test_batch_case_poll_limit() {
+        // given
+        KAFKA_FETCH_POLL_SIZE = 20; // Reducing threshold for purposes of test.
+        final int RECORD_COUNT = 4; // Will take five iterations to hit threshold
+        ConsumerRecords<String, RequestFK> cRecords = generateConsumerRecords(RECORD_COUNT);
+        // It will take 5 messages to hit threshold
+        when(consumerMock.poll(any())).thenReturn(cRecords,cRecords,cRecords,cRecords,cRecords,emptyRecords);
+
+        // when
+        boolean result = processor.receiver(consumerMock, createEphemeral(TOPIC), Duration.ofMillis(1));
+
+        // then
+        assertTrue(result);
+        verify(mockProcessor).startBatch(anyInt(),anyLong());
+        verify(mockProcessor, times(20)).process(any());// 5 messages of 4 records
+        verify(mockProcessor).finishBatch(anyInt(),anyLong(),anyLong());
+    }
+
+    /**
+     * In this test, we replicate an ongoing update whereby messages come in
+     * constantly in small amounts. We will then batch the message till we
+     * trip one of the limits, in this case the records size (KAFKA_FETCH_BYTE_SIZE).
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    public void test_batch_case_size_limit() {
+        // given
+        KAFKA_FETCH_BYTE_SIZE = 40; // Reducing threshold for purposes of test (in bytes).
+        DataState dataState = createEphemeral(TOPIC);
+        final int RECORD_COUNT = 4;// Each generated message is approximately 6 bytes (x4=28 Bytes).
+        ConsumerRecords<String, RequestFK> cRecords = generateConsumerRecords(RECORD_COUNT);
+        // It will take two messages to pass the limit (56 Bytes)
+        when(consumerMock.poll(any())).thenReturn(cRecords,cRecords,emptyRecords);
+
+        // when
+        boolean result = processor.receiver(consumerMock, dataState, Duration.ofMillis(1));
+
+        // then
+        assertTrue(result);
+        verify(mockProcessor).startBatch(anyInt(),anyLong());
+        verify(mockProcessor, times(8)).process(any()); // 2 messages of 4 records
+        verify(mockProcessor).finishBatch(anyInt(),anyLong(),anyLong());
+    }
+
+
+    private ConsumerRecords<String, RequestFK> generateConsumerRecords(int records) {
+        List<ConsumerRecord<String,RequestFK>> consumerRecordList = new ArrayList<>();
+        for (int i = 0; i < records; i++) {
+            consumerRecordList.add(new ConsumerRecord<>(TOPIC, 1, i, "Key", new RequestFK("test", Map.of(), String.format("Test-%s", i).getBytes())));
+        }
+        return new ConsumerRecords<>(Map.of(
+                new TopicPartition(TOPIC, 1), consumerRecordList)
+        );
+    }
+}

--- a/jena-kafka-connector/src/main/java/org/apache/jena/kafka/SysJenaKafka.java
+++ b/jena-kafka-connector/src/main/java/org/apache/jena/kafka/SysJenaKafka.java
@@ -31,8 +31,6 @@ public class SysJenaKafka {
     /** Software version taken from the jar file. */
     public static final String VERSION      = Version.versionForClass(FusekiKafka.class).orElse("<development>");
 
-    public static void init() {}
-
     /**
      * Size in bytes per consumer.poll in a system.
      * <p>
@@ -44,7 +42,7 @@ public class SysJenaKafka {
      * {@link ConsumerConfig#FETCH_MAX_BYTES_CONFIG} which has a Kafka default of
      * 50Mb.
      */
-    private static int KafkaFetchBytesSize = 50 * 1024 * 1024;
+    public static int KAFKA_FETCH_BYTE_SIZE = 50 * 1024 * 1024;
 
     /**
      * Size in messages per consumer.poll in a system.
@@ -52,7 +50,7 @@ public class SysJenaKafka {
      * This sets {@link ConsumerConfig#MAX_POLL_RECORDS_CONFIG} ({@code max.poll.records})
      * which has a Kafka default of 500.
      */
-    private static int KafkaFetchPollSize = 5000;
+    public static int KAFKA_FETCH_POLL_SIZE = 5000;
 
     /**
      * Kafka consumer properties.
@@ -60,8 +58,8 @@ public class SysJenaKafka {
     public static Properties consumerProperties(String server) {
         Properties props = new Properties();
         props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
-        props.put(ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG, KafkaFetchBytesSize);
-        props.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, KafkaFetchPollSize);
+        props.put(ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG, KAFKA_FETCH_BYTE_SIZE);
+        props.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, KAFKA_FETCH_POLL_SIZE);
 
         // Default is 50M
         //props.put(ConsumerConfig.FETCH_MAX_BYTES_CONFIG, 50*1024*1024);

--- a/pom.xml
+++ b/pom.xml
@@ -208,6 +208,13 @@
 
       <dependency>
         <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>${ver.mockito}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.mockito</groupId>
         <artifactId>mockito-junit-jupiter</artifactId>
         <version>${ver.mockito}</version>
         <scope>test</scope>


### PR DESCRIPTION
There is a situation that can arise whereby the Kafka processing can be far quicker than the applications populating Kafka can supply it. This results in the inefficient processing of 1/2 messages at a time, rather than a more meaningful amount. 

To address this, when polling Kafka,  if the returned number of records is below a threshold, we will poll again. This has the effect of ensuring that resources aren't wasted in the application. 

Whenever we poll Kafka we will review the results and do as follows:
1. Empty - continue processing as before.
2. More records than threshold - continue processing as before.
3. Less records than threshold:
     (a) payload size above threshold - continue processing as before
     (b) record count above threshold - continue processing as before.
     (c) Otherwise - combine results thus far (updating payload size / record count values), poll again and repeat.

At present the values to compare against are (and are set to):
- MIN_BATCH_CHECK_THRESHOLD (25)
- KAFKA_FETCH_POLL_SIZE (5,000 records)
- KAFKA_FETCH_BYTE_SIZE (50Mb)

At some point we may wish to make these values configurable or make separate size/count values, say MIN_BATCH_SIZE_LIMIT & MIN_BATCH_RECORD_LIMIT. Tickets can be raised based upon the results of wider testing.