### PR TITLE
Make when Kafka Connectors start flexible (CORE-443)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Kafka Connector for Apache Jena Fuseki
 
+## 1.3.6
+
+- `FMod_FusekiKafka` makes `startKafkaConnectors()` a protected method to allow derived modules flexiblity in deciding
+  when to start the Kafka Connectors as there are trade off involved, see Javadoc on that method for discussion
+- Upgraded Protobuf to 4.27.5
+- Various build and test dependencies upgraded to latest available
+
 ## 1.3.5
 
 - Improved Kafka batching strategy to further reduce small batch consumption of Kafka records where possible

--- a/jena-fmod-kafka/pom.xml
+++ b/jena-fmod-kafka/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>io.telicent.jena</groupId>
     <artifactId>jena-kafka</artifactId>
-    <version>1.3.6-SNAPSHOT</version>
+    <version>1.4.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent> 
 
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>io.telicent.jena</groupId>
       <artifactId>jena-fuseki-kafka-module</artifactId>
-      <version>1.3.6-SNAPSHOT</version>
+      <version>1.4.0-SNAPSHOT</version>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>

--- a/jena-fuseki-kafka-module/pom.xml
+++ b/jena-fuseki-kafka-module/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>io.telicent.jena</groupId>
     <artifactId>jena-kafka</artifactId>
-    <version>1.3.6-SNAPSHOT</version>
+    <version>1.4.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -40,13 +40,20 @@
     <dependency>
       <groupId>io.telicent.jena</groupId>
       <artifactId>jena-kafka-connector</artifactId>
-      <version>1.3.6-SNAPSHOT</version>
+      <version>1.4.0-SNAPSHOT</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.jena</groupId>
       <artifactId>jena-fuseki-main</artifactId>    
-    </dependency> 
+    </dependency>
+
+    <!-- CVE-2024-7254 -->
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>${ver.protobuf}</version>
+    </dependency>
 
     <dependency>
       <groupId>org.junit.platform</groupId>

--- a/jena-fuseki-kafka-module/src/main/java/org/apache/jena/fuseki/kafka/FMod_FusekiKafka.java
+++ b/jena-fuseki-kafka-module/src/main/java/org/apache/jena/fuseki/kafka/FMod_FusekiKafka.java
@@ -44,8 +44,7 @@ import org.apache.jena.sparql.core.assembler.AssemblerUtils;
 import org.apache.jena.sparql.util.graph.GraphUtils;
 
 /**
- * Connect Kafka to a dataset. Messages on a Kafka topic are HTTP-like:
- * updates (add data), SPARQL Update or RDF patch.
+ * Connect Kafka to a dataset. Messages on a Kafka topic are HTTP-like: updates (add data), SPARQL Update or RDF patch.
  */
 public class FMod_FusekiKafka implements FusekiAutoModule {
 
@@ -53,13 +52,16 @@ public class FMod_FusekiKafka implements FusekiAutoModule {
 
     private static void init() {
         boolean b = INITIALIZED.getAndSet(true);
-        if ( b )
-            // Already done.
+        if (b)
+        // Already done.
+        {
             return;
+        }
         AssemblerUtils.registerAssembler(null, KafkaConnectorAssembler.getType(), new KafkaConnectorAssembler());
     }
 
-    public FMod_FusekiKafka() {}
+    public FMod_FusekiKafka() {
+    }
 
     // The Fuseki modules build lifecycle is same-thread.
     // This passes information from 'prepare' to 'server'
@@ -80,12 +82,12 @@ public class FMod_FusekiKafka implements FusekiAutoModule {
         init();
         Log.info(Fuseki.configLog, logMessage());
 
-        if ( configModel == null ) {
+        if (configModel == null) {
             // FmtLog.error(LOG, "No server configuration. Can't build connector");
-            return ;
+            return;
         }
         List<Resource> connectors = GraphUtils.findRootsByType(configModel, KafkaConnectorAssembler.getType());
-        if ( connectors.isEmpty() ) {
+        if (connectors.isEmpty()) {
             // FmtLog.error(LOG, "No connector in server configuration");
             return;
         }
@@ -95,7 +97,7 @@ public class FMod_FusekiKafka implements FusekiAutoModule {
     /*package*/ void oneConnector(FusekiServer.Builder builder, Resource connector, Model configModel) {
         KConnectorDesc conn;
         try {
-            conn = (KConnectorDesc)Assembler.general.open(connector);
+            conn = (KConnectorDesc) Assembler.general.open(connector);
         } catch (JenaException ex) {
             FmtLog.error(LOG, "Failed to build a connector", ex);
             return;
@@ -130,19 +132,54 @@ public class FMod_FusekiKafka implements FusekiAutoModule {
 
     /**
      * Add each connector, with the state tracker, to the server configured server.
+     * <p>
+     * See notes on {@link #startKafkaConnectors(FusekiServer)} about potential pitfalls of starting connectors at this
+     * point in the server lifecycle.  Derived modules <strong>MAY</strong> wish to override this method to not start
+     * the connectors at this stage and override {@link #serverAfterStarting(FusekiServer)}, or another lifecycle method
+     * instead.
+     * </p>
      */
     @Override
     public void serverBeforeStarting(FusekiServer server) {
         // server(FusekiServer server) -- after build, before returning to builder caller
-        // See also serverBeforeStarting which is an even later delayed setup point.
+        // See also serverAfterStarting which is an even later delayed setup point.
+        startKafkaConnectors(server);
+    }
+
+    /**
+     * Starts the Kafka Connectors
+     * <p>
+     * This needs to be called once, and only once, by this module.  By default this gets called from the
+     * {@link #serverBeforeStarting(FusekiServer)} method, this means that Fuseki will guarantee it is up to date on all
+     * topics before it starts servicing any requests.
+     * </p>
+     * <p>
+     * Note that if the server is lagging far behind the Kafka topic(s) it is being subscribed to then it will take a
+     * long time before Fuseki is able to service requests.  This may be problematic if you are deployed this in an
+     * environment that relies on HTTP Health Probes as the HTTP Server is not started while Fuseki is catching up on
+     * the Kafka topics.  This can result in the service being placed into a Crash Restart Loop as it fails health
+     * checks and is restarted.
+     * </p>
+     * <p>
+     * Also bear in mind that if the producers writing data to the Kafka topic(s) that Fuseki is consuming are doing so
+     * at a rate faster than Fuseki can process those updates the service can potentially never reach a ready state.
+     * </p>
+     * <p>
+     * Therefore, derived implementations <strong>MAY</strong> prefer to call this at a different point in the lifecycle
+     * e.g. {@link #serverAfterStarting(FusekiServer)} and live with the graph being eventually consistent
+     * </p>
+     *
+     * @param server Fuseki Server
+     */
+    protected void startKafkaConnectors(FusekiServer server) {
         List<Pair<KConnectorDesc, DataState>> connectors = connectors(server);
-        if ( connectors == null )
+        if (connectors == null) {
             return;
-        connectors.forEach(pair->{
+        }
+        connectors.forEach(pair -> {
             KConnectorDesc conn = pair.getLeft();
             DataState dataState = pair.getRight();
-            FmtLog.info(LOG, "[%s] Starting connector between %s topic %s and endpoint %s",
-                        conn.getTopic(),
+            FmtLog.info(LOG, "[%s] Starting connector between %s topic %s and endpoint %s", conn.getTopic(),
                         conn.getBootstrapServers(), conn.getTopic(),
                         conn.dispatchLocal() ? conn.getLocalDispatchPath() : conn.getRemoteEndpoint());
             FKBatchProcessor batchProcessor = makeFKBatchProcessor(conn, server);
@@ -150,7 +187,9 @@ public class FMod_FusekiKafka implements FusekiAutoModule {
         });
     }
 
-    /** Clearup build state. */
+    /**
+     * Clear-up build state.
+     */
     @Override
     public void serverAfterStarting(FusekiServer server) {
         // Clear up thread local.
@@ -159,10 +198,9 @@ public class FMod_FusekiKafka implements FusekiAutoModule {
     }
 
     /**
-     * Make a {@link FKBatchProcessor} for the Fuseki Server being built. The default
-     * is one that loops on the ConsumerRecords ({@link RequestFK}) sending each to
-     * the Fuseki server for dispatch. Other policies are possible such as
-     * aggregating batches or directly applying to a dataset.
+     * Make a {@link FKBatchProcessor} for the Fuseki Server being built. The default is one that loops on the
+     * ConsumerRecords ({@link RequestFK}) sending each to the Fuseki server for dispatch. Other policies are possible
+     * such as aggregating batches or directly applying to a dataset.
      */
     protected FKBatchProcessor makeFKBatchProcessor(KConnectorDesc conn, FusekiServer server) {
         return FKS.plainFKBatchProcessor(conn, server.getServletContext());
@@ -171,9 +209,10 @@ public class FMod_FusekiKafka implements FusekiAutoModule {
     @Override
     public void serverStopped(FusekiServer server) {
         List<Pair<KConnectorDesc, DataState>> connectors = connectors(server);
-        if ( connectors == null )
+        if (connectors == null) {
             return;
-        connectors.forEach(pair->{
+        }
+        connectors.forEach(pair -> {
             KConnectorDesc conn = pair.getLeft();
             DataState dataState = pair.getRight();
             FKRegistry.get().unregister(conn.getTopic());

--- a/jena-kafka-client/pom.xml
+++ b/jena-kafka-client/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>io.telicent.jena</groupId>
     <artifactId>jena-kafka</artifactId>
-    <version>1.3.6-SNAPSHOT</version>
+    <version>1.4.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent> 
 
@@ -41,7 +41,7 @@
     <dependency>
       <groupId>io.telicent.jena</groupId>
       <artifactId>jena-kafka-connector</artifactId>
-      <version>1.3.6-SNAPSHOT</version>
+      <version>1.4.0-SNAPSHOT</version>
     </dependency>
     
     <!--

--- a/jena-kafka-connector/pom.xml
+++ b/jena-kafka-connector/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>io.telicent.jena</groupId>
     <artifactId>jena-kafka</artifactId>
-    <version>1.3.6-SNAPSHOT</version>
+    <version>1.4.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent> 
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <groupId>io.telicent.jena</groupId>
   <artifactId>jena-kafka</artifactId>
   <packaging>pom</packaging>
-  <version>1.3.6-SNAPSHOT</version>
+  <version>1.4.0-SNAPSHOT</version>
 
   <name>Apache Jena Fuseki-Kafka Connector</name>
   <description>Fuseki Module : Kafka Connector</description>
@@ -59,13 +59,13 @@
     <build.time.xsd>${maven.build.timestamp}</build.time.xsd>
     
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <project.build.outputTimestamp>2024-09-10T13:43:33Z</project.build.outputTimestamp>
+    <project.build.outputTimestamp>2024-09-20T08:59:47Z</project.build.outputTimestamp>
 
     <java.version>17</java.version>
 
     <ver.jena>5.1.0</ver.jena>
-
-    <ver.kafka>3.8.0</ver.kafka> 
+    <ver.kafka>3.8.0</ver.kafka>
+    <ver.protobuf>4.27.5</ver.protobuf> <!-- CVE-2024-7254 -->
 
     <ver.slf4j>2.0.7</ver.slf4j>
     <ver.log4j2>2.24.0</ver.log4j2>
@@ -140,6 +140,11 @@
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
           </exclusion>
+          <!-- CVE-2024-7254 -->
+          <exclusion>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
 
@@ -153,6 +158,13 @@
         <groupId>org.apache.jena</groupId>
         <artifactId>jena-fuseki-main</artifactId>
         <version>${ver.jena}</version>
+      </dependency>
+
+      <!-- CVE-2024-7254 -->
+      <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-java</artifactId>
+        <version>${ver.protobuf}</version>
       </dependency>
 
       <!-- The combined jar for Fuseki main -->


### PR DESCRIPTION
Under some circumanstances, especially when custom batching strategies are used, it is possible for Fuseki to take a very long time, or even never start servicing requests, due to how Kafka Connectors are starters.  This commit makes the starting of the connectors a protected method so derived modules can override the lifecycle stage where Kafka connectors are started.