### PR TITLE
Complete 1.4.0 Release

### DIFF
--- a/jena-fmod-kafka/pom.xml
+++ b/jena-fmod-kafka/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>io.telicent.jena</groupId>
     <artifactId>jena-kafka</artifactId>
-    <version>1.4.0</version>
+    <version>1.4.1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent> 
 
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>io.telicent.jena</groupId>
       <artifactId>jena-fuseki-kafka-module</artifactId>
-      <version>1.4.0</version>
+      <version>1.4.1-SNAPSHOT</version>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>

--- a/jena-fmod-kafka/pom.xml
+++ b/jena-fmod-kafka/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>io.telicent.jena</groupId>
     <artifactId>jena-kafka</artifactId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.4.0</version>
     <relativePath>..</relativePath>
   </parent> 
 
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>io.telicent.jena</groupId>
       <artifactId>jena-fuseki-kafka-module</artifactId>
-      <version>1.4.0-SNAPSHOT</version>
+      <version>1.4.0</version>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>

--- a/jena-fuseki-kafka-module/pom.xml
+++ b/jena-fuseki-kafka-module/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>io.telicent.jena</groupId>
     <artifactId>jena-kafka</artifactId>
-    <version>1.4.0</version>
+    <version>1.4.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>io.telicent.jena</groupId>
       <artifactId>jena-kafka-connector</artifactId>
-      <version>1.4.0</version>
+      <version>1.4.1-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/jena-fuseki-kafka-module/pom.xml
+++ b/jena-fuseki-kafka-module/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>io.telicent.jena</groupId>
     <artifactId>jena-kafka</artifactId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.4.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>io.telicent.jena</groupId>
       <artifactId>jena-kafka-connector</artifactId>
-      <version>1.4.0-SNAPSHOT</version>
+      <version>1.4.0</version>
     </dependency>
 
     <dependency>

--- a/jena-kafka-client/pom.xml
+++ b/jena-kafka-client/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>io.telicent.jena</groupId>
     <artifactId>jena-kafka</artifactId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.4.0</version>
     <relativePath>..</relativePath>
   </parent> 
 
@@ -41,7 +41,7 @@
     <dependency>
       <groupId>io.telicent.jena</groupId>
       <artifactId>jena-kafka-connector</artifactId>
-      <version>1.4.0-SNAPSHOT</version>
+      <version>1.4.0</version>
     </dependency>
     
     <!--

--- a/jena-kafka-client/pom.xml
+++ b/jena-kafka-client/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>io.telicent.jena</groupId>
     <artifactId>jena-kafka</artifactId>
-    <version>1.4.0</version>
+    <version>1.4.1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent> 
 
@@ -41,7 +41,7 @@
     <dependency>
       <groupId>io.telicent.jena</groupId>
       <artifactId>jena-kafka-connector</artifactId>
-      <version>1.4.0</version>
+      <version>1.4.1-SNAPSHOT</version>
     </dependency>
     
     <!--

--- a/jena-kafka-connector/pom.xml
+++ b/jena-kafka-connector/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>io.telicent.jena</groupId>
     <artifactId>jena-kafka</artifactId>
-    <version>1.4.0</version>
+    <version>1.4.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent> 
 

--- a/jena-kafka-connector/pom.xml
+++ b/jena-kafka-connector/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>io.telicent.jena</groupId>
     <artifactId>jena-kafka</artifactId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.4.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent> 
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <groupId>io.telicent.jena</groupId>
   <artifactId>jena-kafka</artifactId>
   <packaging>pom</packaging>
-  <version>1.4.0</version>
+  <version>1.4.1-SNAPSHOT</version>
 
   <name>Apache Jena Fuseki-Kafka Connector</name>
   <description>Fuseki Module : Kafka Connector</description>
@@ -52,14 +52,14 @@
     <connection>scm:git:git@github.com:telicent-oss/jena-fuseki-kafka</connection>
     <developerConnection>scm:git:git@github.com:telicent-oss/jena-fuseki-kafka</developerConnection>
     <url>https://github.com/telicent-oss/jena-fuseki-kafka</url>
-    <tag>1.4.0</tag>
+    <tag>1.3.2</tag>
   </scm>
 
   <properties>
     <build.time.xsd>${maven.build.timestamp}</build.time.xsd>
     
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <project.build.outputTimestamp>2024-09-20T10:28:41Z</project.build.outputTimestamp>
+    <project.build.outputTimestamp>2024-09-20T10:32:13Z</project.build.outputTimestamp>
 
     <java.version>17</java.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <groupId>io.telicent.jena</groupId>
   <artifactId>jena-kafka</artifactId>
   <packaging>pom</packaging>
-  <version>1.4.0-SNAPSHOT</version>
+  <version>1.4.0</version>
 
   <name>Apache Jena Fuseki-Kafka Connector</name>
   <description>Fuseki Module : Kafka Connector</description>
@@ -52,14 +52,14 @@
     <connection>scm:git:git@github.com:telicent-oss/jena-fuseki-kafka</connection>
     <developerConnection>scm:git:git@github.com:telicent-oss/jena-fuseki-kafka</developerConnection>
     <url>https://github.com/telicent-oss/jena-fuseki-kafka</url>
-    <tag>1.3.2</tag>
+    <tag>1.4.0</tag>
   </scm>
 
   <properties>
     <build.time.xsd>${maven.build.timestamp}</build.time.xsd>
     
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <project.build.outputTimestamp>2024-09-20T08:59:47Z</project.build.outputTimestamp>
+    <project.build.outputTimestamp>2024-09-20T10:28:41Z</project.build.outputTimestamp>
 
     <java.version>17</java.version>
 


### PR DESCRIPTION
Note there seemed to be a transient failure in the Maven Central Release with this repository.  The `1.4.0` build failed - https://github.com/telicent-oss/jena-fuseki-kafka/actions/runs/10957676990/job/30426535055 - due to a timeout after 15 minutes so perhaps Maven Central was just overloaded at the time.  I went manually into the Nexus UI and was able to click release on the staged artefacts and they are now present in Maven Central

