### PR TITLE
[CORE-622] Adding functionality to reset Kafka Consumer offsets to given value (for a selected dataset).

### DIFF
--- a/jena-fuseki-kafka-module/pom.xml
+++ b/jena-fuseki-kafka-module/pom.xml
@@ -105,6 +105,13 @@
       </exclusions>
     </dependency>
 
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>${dependency.awaitility}</version>
+      <scope>test</scope>
+    </dependency>
+
     <!-- Adding to avoid incompatibility with older versions and Test Containers -->
     <dependency>
       <groupId>commons-io</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
     <plugin.exec>3.5.0</plugin.exec>
     <plugin.gpg>3.2.7</plugin.gpg>
     <plugin.install>3.1.3</plugin.install>
+    <plugin.jacoco>0.8.12</plugin.jacoco>
     <plugin.jar>3.4.2</plugin.jar>
     <plugin.javadoc>3.11.1</plugin.javadoc>
     <plugin.nexus>1.7.0</plugin.nexus>
@@ -92,6 +93,7 @@
     <dependency.slf4j>2.0.7</dependency.slf4j>
 
     <!-- Test dependencies -->
+    <dependency.awaitility>4.2.0</dependency.awaitility>
     <dependency.junit5>5.11.3</dependency.junit5>
     <dependency.junit5-platform>1.10.1</dependency.junit5-platform>
     <dependency.mockito>5.14.2</dependency.mockito>
@@ -290,6 +292,7 @@
           <argLine>
             --add-opens java.base/java.util=ALL-UNNAMED
             --add-opens java.base/java.lang=ALL-UNNAMED
+            @{jacocoArgLine} -XX:+EnableDynamicAgentLoading
           </argLine>
         </configuration>
       </plugin>
@@ -459,6 +462,30 @@
           <stagingProgressTimeoutMinutes>15</stagingProgressTimeoutMinutes>
         </configuration>
       </plugin>
+
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>${plugin.jacoco}</version>
+        <configuration>
+          <propertyName>jacocoArgLine</propertyName>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
 
     </plugins>
   </build>


### PR DESCRIPTION
Caveats apply - which are listed on the JIRA ticket. 

Also added Jacoco reporting but not the coverage checks. 