### PR TITLE
Limit max transaction duration (CORE-707)

### DIFF
--- a/jena-fuseki-kafka-module/src/test/java/org/apache/jena/fuseki/kafka/DockerTestKafkaDelays.java
+++ b/jena-fuseki-kafka-module/src/test/java/org/apache/jena/fuseki/kafka/DockerTestKafkaDelays.java
@@ -15,6 +15,7 @@ import org.apache.jena.sys.JenaSystem;
 import org.apache.jena.system.G;
 import org.apache.jena.vocabulary.RDF;
 import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.CreateTopicsResult;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.testcontainers.containers.KafkaContainer;

--- a/jena-fuseki-kafka-module/src/test/resources/logback-test.xml
+++ b/jena-fuseki-kafka-module/src/test/resources/logback-test.xml
@@ -18,7 +18,7 @@
     <!-- Kafka's NetworkClient is very chatty! -->
     <logger name="org.apache.kafka.clients.NetworkClient" level="ERROR" />
 
-    <root level="OFF">
+    <root level="INFO">
         <appender-ref ref="STDERR" />
     </root>
 </configuration>

--- a/jena-kafka-connector/pom.xml
+++ b/jena-kafka-connector/pom.xml
@@ -47,6 +47,11 @@
             <artifactId>event-source-kafka</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.telicent.smart-caches</groupId>
+            <artifactId>projector-driver</artifactId>
+            <version>${dependency.smart-caches}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-arq</artifactId>
         </dependency>

--- a/jena-kafka-connector/src/main/java/org/apache/jena/kafka/common/FusekiProjector.java
+++ b/jena-kafka-connector/src/main/java/org/apache/jena/kafka/common/FusekiProjector.java
@@ -3,7 +3,6 @@ package org.apache.jena.kafka.common;
 import io.telicent.smart.cache.observability.RuntimeInfo;
 import io.telicent.smart.cache.payloads.RdfPayload;
 import io.telicent.smart.cache.payloads.RdfPayloadException;
-import io.telicent.smart.cache.projectors.Projector;
 import io.telicent.smart.cache.projectors.Sink;
 import io.telicent.smart.cache.projectors.driver.StallAwareProjector;
 import io.telicent.smart.cache.sources.Event;

--- a/jena-kafka-connector/src/test/java/org/apache/jena/kafka/common/RemainingNullEventSource.java
+++ b/jena-kafka-connector/src/test/java/org/apache/jena/kafka/common/RemainingNullEventSource.java
@@ -1,0 +1,22 @@
+package org.apache.jena.kafka.common;
+
+import io.telicent.smart.cache.sources.Event;
+import io.telicent.smart.cache.sources.memory.InMemoryEventSource;
+
+import java.util.Collection;
+
+public class RemainingNullEventSource<TKey, TValue> extends InMemoryEventSource<TKey, TValue> {
+    /**
+     * Creates a new in-memory event source
+     *
+     * @param events Events that the source will provide
+     */
+    public RemainingNullEventSource(Collection<Event<TKey, TValue>> events) {
+        super(events);
+    }
+
+    @Override
+    public Long remaining() {
+        return null;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -375,7 +375,10 @@
                     <argLine>
                         --add-opens java.base/java.util=ALL-UNNAMED
                         --add-opens java.base/java.lang=ALL-UNNAMED
-                        @{jacocoArgLine} -XX:+EnableDynamicAgentLoading
+                        @{jacocoArgLine}
+                        -javaagent:${org.mockito:mockito-core:jar}
+                        -XX:+EnableDynamicAgentLoading
+                        -Xshare:off
                     </argLine>
                 </configuration>
             </plugin>
@@ -447,6 +450,14 @@
                     <overWriteReleases>false</overWriteReleases>
                     <overWriteIfNewer>true</overWriteIfNewer>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>properties</id>
+                        <goals>
+                            <goal>properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
 
             <!-- Run the enforcer plugin automatically at compile time -->


### PR DESCRIPTION
Adds a limit on max transaction duration to the `FusekiProjector` so that if reading from topics populated by a slow low volume producer the batch is not held open indefinitely and is periodically committed.  This prevents undue delays in data being visible in the graph.

# Related Issues and PRs

- This resolved CORE-707