### PR TITLE
Various Fixes and Improvements (CORE-834)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,14 @@ integration tests than the existing one-off code in this repository was.
   connector during startup
     - These should now throw an error that halts Fuseki startup
 
+### Build and Test Improvements
+
+- Upgraded Apache Commons BeanUtils to 1.11.0
+- Upgraded Apache Jena to 5.4.0
+- Upgraded Apache Kafka to 3.9.1
+- Upgraded Smart Caches Core Libraries to 0.29.1
+- Upgraded various build and test dependencies to latest available
+
 ## 1.5.3
 
 - Upgraded Apache Jena to 5.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ integration tests than the existing one-off code in this repository was.
     - The Smart Cache Core libraries we are using include various connectivity, and topic existence checking, plus error
       handling and logging for lots more Kafka failure scenarios.  These scenarios will now be surfaced in the Fuseki
       logs so should be monitored for and addressed accordingly.
+- The module no longer requires that connectors be fully up to date with Kafka topics prior to allowing Fuseki to start
+  and service requests.
+    - This fixes a bug where Fuseki Kafka could find itself in a crash restart loop if external monitoring health checks
+      were trying to make HTTP requests to see if it was ready to service requests.  This crash restart loop would
+      continue until such time as it caught up with the topic(s), assuming it did catch up.
 - Removed unimplemented support for dispatching events to a remote endpoint
     - **NB** This was a placeholder for future functionality for which we had no actual use cases
 - Removed deprecated `MockKafka`

--- a/README.md
+++ b/README.md
@@ -2,44 +2,20 @@
 
 Apache Jena Fuseki extension module for receiving data over Apache Kafka topics.
 
-License: Apache License 2.0.  
-See [LICENSE](./LICENSE).
-
 The Fuseki-Kafka connector receives Kafka events on a topic and applies them to a Fuseki service endpoint. In effect, it
 is the same as if an HTTP POST request is sent to the Fuseki service.
 
-The Kafka event must have a Kafka message header `Content-Type` set to the MIME type of the content. No other headers
-are required.
+The Kafka event **SHOULD** have a Kafka message header `Content-Type` set to the MIME type of the content, if not
+present then NQuads is assumed. No other headers are required.
 
 Supported MIME types:
-* An RDF triples or quads format - any syntax supported by 
-  Apache Jena - `application/n-triples`, `text/turtle`, ...
-* SPARQL Update
-* [RDF Patch](https://jena.apache.org/documentation/rdf-patch/)
 
-The Fuseki service must be configured with the appropriate operations. `fuseki:gsp-rw` or `fuseki:upload` for pushing
-RDF into a dataset; `fuseki:update` for SPARQL Update, `fuseki:patch` for RDF Patch. The Fuseki implementation of the
-SPARQL Graph Store Protocol is extended to support data sent to the dataset without graph name (i.e. quads).
+- An RDF triples or quads format - any syntax supported by Apache Jena - `application/n-triples`, `text/turtle`, ...
+- [RDF Patch](https://jena.apache.org/documentation/rdf-patch/)
 
-```
-:service rdf:type fuseki:Service ;
-    fuseki:name "ds" ;
-    fuseki:endpoint [ fuseki:operation fuseki:query ] ;
-    ...
-
-    # Fuseki-Kafka
-    fuseki:endpoint [ fuseki:operation fuseki:update ] ;
-    fuseki:endpoint [ fuseki:operation fuseki:gsp-rw ] ;
-    fuseki:endpoint [ fuseki:operation fuseki:patch ] ;
-    ...
-    fuseki:dataset ... ;
-    .
-```
-
-See [Configuring Fuseki](https://jena.apache.org/documentation/fuseki2/fuseki-configuration.html) for access control and
-other features.
-
-This project uses the Apache Jena Fuseki Main server and is configured with a Fuseki configuration file.
+See [Configuring Fuseki](https://jena.apache.org/documentation/fuseki2/fuseki-configuration.html) for general Fuseki
+configuration documentation.  This project uses the Apache Jena Fuseki Main server and is configured with a Fuseki
+configuration file.
 
 Java 17 or later is required.
 
@@ -59,21 +35,21 @@ PREFIX ja:      <http://jena.hpl.hp.com/2005/11/Assembler#>
     # Kafka topic
     fk:topic              "env:{ENV_KAFKA_TOPIC:RDF}";
    
-
-    # Destination Fuseki service. This is a URI path (no scheme, host or port).
-    # This can be the dataset, a specific endpoint ("/ds/kafkaIncoming")
-    # with the necessary fuseki:operation.
+    # Destination Fuseki service. This is the base URI path for the dataset
     
     fk:fusekiServiceName  "/ds";
 
-    # Using Kafka-RAFT
+    # Specify the Kafka bootstrap servers
     fk:bootstrapServers   "localhost:9092";
 
     # File used to track the state (the last offset processes)
     # Used across Fuseki restarts.
     fk:stateFile        "Databases/RDF.state";
 
-    # Kafka GroupId - default "JenaFusekiKafka"
+    # Kafka Consumer GroupId - default "JenaFusekiKafka"
+    # MUST be unique across all connectors in your config file
+    # If you are running multiple Fuseki instances then this MUST be unique for each instance otherwise only a single
+    # instance will actually read data from the Kafka topic
     # fk:groupId          "JenaFusekiKafka";
 
     # What to do on start up.
@@ -90,22 +66,10 @@ PREFIX ja:      <http://jena.hpl.hp.com/2005/11/Assembler#>
     .
 ```
 
-Note that the Fuseki Kafka Module by default starts the Kafka connectors prior to the Fuseki HTTP Server starting and
-attempts to catch up with the Kafka topic(s) prior to allowing the HTTP Server to start.  Depending on the batching
-strategy that you have implemented for messages this **MAY** block the HTTP Server from starting for a prolonged period.
-While this ensures that Fuseki is up to date with the Kafka topic(s) it does have some potential pitfalls:
-
-- If Fuseki is a long way behind the Kafka topic(s), or `fk:replay true` was set, then it may take a very long time
-  before Fuseki can service requests.
-    - If you are deploying Fuseki somewhere that relies on HTTP Health Checks against the server you may find Fuseki
-      goes into a Crash Restart Loop as a result which further delays it's ability to catch up with the Kafka topic(s)
-- If there are active producers writing to the Kafka topic(s) faster than Fuseki can read from them it could never catch
-  up, and never start servicing HTTP requests.
-
-Therefore as of `1.4.0` the connector start has been placed into its own `startKafkaConnectors()` method allowing
-developers to choose to extend `FMod_FusekiKafka` and override `serverBeforeStarting()` to not call this method and
-instead call it from a different lifecycle method e.g. `serverAfterStarting()`.  You can find more discussion on this in
-the Javadoc on `FMod_FusekiKafka`
+Note that the Fuseki Kafka Module by default starts the Kafka connectors prior to the Fuseki HTTP Server starting,
+waiting briefly to see if each starts successfully.  The Kafka polling happens on background threads writing into the
+targeted dataset.  If there are active producers writing to the Kafka topic(s) faster than Fuseki can read from them it
+could never catch up, and never start servicing HTTP requests.
 
 ### Environment variable configuration
 
@@ -199,8 +163,9 @@ Authentication modes are applicable.
 ## Build
 
 Run
+
 ```
-   mvn clean package
+mvn clean package
 ```
 This includes running Apache Kafka via docker containers from `testcontainers.io`. There is a large, one time, download.
 
@@ -225,7 +190,6 @@ Dry run
 ```
 mvn $MVN_ARGS -DdryRun=true release:clean release:prepare
 ```
-
 and for real
 
 ```
@@ -255,30 +219,20 @@ mvn versions:set -DnewVersion=...-SNAPSHOT
 
 In the directory where you wish to run Fuseki:
 
-Get a copy of Fuseki Main:
+Get a copy of Fuseki Main from the [Apache Jena
+Downloads](https://jena.apache.org/download/index.cgi#apache-jena-binary-distributions) page and place in the current
+directory.
+
+Use the script [`fuseki-main`](https://github.com/Telicent-io/jena-fuseki-kafka/blob/main/fuseki-main) from this
+repository then run:
 
 ```
-wget https://repo1.maven.org/maven2/org/apache/jena/jena-fuseki-server/4.7.0/jena-fuseki-server-4.7.0.jar
-```
-and place in the current directory.
-
-Get a copy of the script [fuseki-main](https://github.com/Telicent-io/jena-fuseki-kafka/blob/main/fuseki-main)
-then run 
-
-```
-fuseki-main jena-fuseki-server-4.7.0.jar --conf config.ttl`
+fuseki-main jena-fuseki-server-4.7.0.jar --conf config.ttl
 ```
 
-where `config.ttl is the configuration file for the server including the
-connector setup.
+Where `config.ttl` is the configuration file for the server including the connector setup.  Windows uses can run
+`fuseki-main.bat` which may need adjusting for the correct version number of Fuseki.
 
-Windows uses can run `fuseki-main.bat` which may need adjusting for the correct
-version number of Fuseki.
+# License
 
-## Client
-
-`jena-fuseki-client` contains a script `fk` for operations on the Kafka topic.
-
-`fk send FILE` sends a file, using the file extension for the MIME type.
-
-`fk dump` dumps the Kafka topic.
+This code is Copyright Telicent Ltd and licensed under Apache License 2.0.  See [LICENSE](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -32,11 +32,12 @@ PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX ja:      <http://jena.hpl.hp.com/2005/11/Assembler#>
 
 <#connector> rdf:type fk:Connector ;
-    # Kafka topic
+    # Kafka topic(s)
+    # Specify once for each input topic you wish to read
+    # Note that each topic MAY only be connected to a single dataset
     fk:topic              "env:{ENV_KAFKA_TOPIC:RDF}";
    
     # Destination Fuseki service. This is the base URI path for the dataset
-    
     fk:fusekiServiceName  "/ds";
 
     # Specify the Kafka bootstrap servers
@@ -58,18 +59,119 @@ PREFIX ja:      <http://jena.hpl.hp.com/2005/11/Assembler#>
     #    fk:replayTopic      true;
     #    fk:syncTopic        true;
 
-   ## Additional Kafka client properties.
-   ## fk:config ( "key" "value") ;
+    # Optionally configure a Dead Letter Queue (DLQ) topic
+    # 
+    # When configured any malformed events are forwarded here
+    # If not configured then malformed events cause event processing to abort
+    # fk:dlqTopic "env:{ENV_KAFKA_TOPIC:RDF.dlq}" ;
 
-   ## Additional Kafka client properties from an external properties file
-   ## fk:configFile "/path/to/kafka.properties" ;
+    # Additional Kafka client properties.
+    fk:config ( "max.poll.records" "1000" )
+    # fk:config ( "key" "value") ;
+
+    # Additional Kafka client properties from an external properties file
+    # fk:configFile "/path/to/kafka.properties" ;
     .
 ```
 
+### Kafka Read Behaviour
+
 Note that the Fuseki Kafka Module by default starts the Kafka connectors prior to the Fuseki HTTP Server starting,
 waiting briefly to see if each starts successfully.  The Kafka polling happens on background threads writing into the
-targeted dataset.  If there are active producers writing to the Kafka topic(s) faster than Fuseki can read from them it
-could never catch up, and never start servicing HTTP requests.
+targeted dataset.  Therefore Fuseki Kafka is eventually consistent, however in the worst case scenario where there are
+active producers writing to the Kafka topic(s) faster than Fuseki can read from them it could never catch up.
+
+As of 2.x Fuseki Kafka uses Kafka Consumer Groups when reading events from the configured Kafka topic(s).  This means
+that you **MUST** either have only a single connector in your Fuseki configuration, or each connector **MUST** specify a
+`fk:groupId` property with a unique consumer group ID.
+
+Note that if you are intending to use Kafka to sync RDF to multiple Fuseki instances then each Fuseki instance **MUST**
+use a unique consumer group ID per topic.  Otherwise your instances may not be assigned any partitions, and thus won't
+receive any RDF.
+
+#### Input Topic(s)
+
+The `fk:topic` property on a connector is used to configure one/more topics to which a Kafka connector will subscribe.
+You **MUST** specify this property at least once per connector, and **MAY** specify it multiple times if you wish.
+
+The partitioning strategy for input topics depends on the RDF you are intending to apply.  If your incoming RDF events
+are only additive, i.e. you only ever add new triples, then you can have as many partitions as you want since the set
+semantics of RDF means regardless of the order of event application the dataset will eventually reach the same state.
+
+However, if your workload involves deleting triples via RDF patches then the order of events matters and you **MUST**
+have only a single partition otherwise events could be applied out of order and deletes not take affect as intended.
+
+Finally, note that Fuseki Kafka restricts that each input Kafka topic **MAY** only be used by a single connector in your
+configuration.
+
+#### `fk:replay` and `fk:sync`
+
+The `fk:replay` and `fk:sync` properties specify boolean values used to configure how Fuseki Kafka reads from the
+configured [input topics](#input-topics).  If not specified then `fk:replay` defaults to `false`, and `fk:sync` defaults
+to `true`.
+
+If both are set to `true` then `fk:replay` takes precedence, depending on the values of these properties, and the
+[`fk:stateFile`](#state-file) property you will get the following read behaviours:
+
+| `fk:replay` | `fk:sync`    | `fk:stateFile` configured? | Read Behaviour                      |
+|-------------|--------------|----------------------------|-------------------------------------|
+| `true`      | `true/false` | Yes/No                     | From beginning of configured topics |
+| `false`     | `true`       | Yes                        | From previously stored offsets in state file, or beginning if no previously stored offsets |
+| `false`     | `false`      | Yes/No                     | From most recent offset             |
+
+So depending on your use case you can configure Fuseki Kafka to read the input topic(s) as needed.  For example if you
+were running a Fuseki instance with a non-persistent dataset then you'd want to set `fk:replay true` so that the dataset
+is rebuilt from the Kafka topic(s) each time Fuseki restarts.
+
+Most users with persistent datsets, e.g. TDB2, will likely want to stick with the default `fk:sync true` behaviour in
+combination with configuring a  [`fk:stateFile`](#state-file) so that your Fuseki instance is kept up to date with the
+Kafka topic(s) over Fuseki restarts.
+
+#### State File
+
+The `fk:stateFile` property sets the location of the persistent state file on disk, this is used to track Kafka offsets.
+If this is not configured then offsets are only tracked on the Kafka brokers and may be ignored on subsequent Fuseki
+restarts.
+
+In the 2.x releases the format of this file changed and it is not backwards compatible with 1.x releases.  If you are
+upgrading from the 1.x releases then Fuseki Kafka does understand the 1.x format state file and will transform it into
+the new format the first time you restart Fuseki with Fuseki Kafka 2.x.x
+
+The state file, and the Kafka Consumer Group offsets, are only updated once Fuseki Kafka has successfully applied and
+`commit()`'d events to the target dataset.  Therefore in the event of a service crash event consumption will resume from
+the last known committed offset, assuming [default `fk:sync` behaviour](#fkreplay-and-fksync) is in use.
+
+### Batching
+
+In the 1.x releases batching was an opt-in behaviour, from practical experience it has become clear that not using
+batching has determinental performance impacts so as of 2.x batching is now core functionality of this module.
+
+Fuseki Kafka batches the application of incoming events from the Kafka topic(s) so that many events may be applied in a
+single transaction to reduce the transaction overheads.  This is especially important when using underlying storage like
+TDB2, which has copy-on-write semantics, where a transaction per event would quickly exhaust disk space.
+
+The default batch size is `5000` events, this may be controlled by setting the `max.poll.records` Kafka configuration to
+the desired value via the `fk:config` property, e.g. in our earlier example this was set to `1000`.  Note that Fuseki
+Kafka **does not** guarantee to honour this batch size exactly and uses various heuristics to decide when to commit a
+batch, e.g., if it has fully caught up with the Kafka topic (i.e. lag is `0`), if there's events buffered in memory from
+earlier Kafka polling, if it hasn't committed in a certain time window etc.  Please see JavaDoc on `FusekiProjector`
+which implements the batching logic for more details.  In general it aims to maximise batch size, and minimise the
+number of transactions wherever possible, while ensuring timely application of events to the target dataset.
+
+### Error Handling
+
+By default error handling is off as of `2.0.0`, if a malformed event is received on the Kafka topic(s), or an event
+cannot be applied, then processing aborts and no further events will be read from Kafka.  This default behaviour was
+changed from the 1.x releases as in those it was possible for a malformed/misapplied event to cause an entire batch of
+events to be discarded and not applied leading to data loss.
+
+For robust error handling we strongly recommend that you use the new `fk:dlqTopic` property to specify a Dead Letter
+Queue (DLQ) topic to which malformed/misapplied events will be written.  A `Dead-Letter-Reason` header will be added to
+those events indicating why they were considered malformed, or failed to apply.  When an error occurs the event is
+written to the DLQ, and Fuseki Kafka guarantees to apply all prior events in the [batch](#batching) before proceeding.
+
+Note that the DLQ topic **MUST NOT** be a topic that is used as an input topic for a connector as otherwise that would
+create an error loop where bad events are injected back into the input topic.
 
 ### Environment variable configuration
 

--- a/jena-fuseki-kafka-module/pom.xml
+++ b/jena-fuseki-kafka-module/pom.xml
@@ -77,6 +77,12 @@
     <!-- External dependencies -->
 
     <dependency>
+      <groupId>commons-beanutils</groupId>
+      <artifactId>commons-beanutils</artifactId>
+      <version>${dependency.commons-beanutils}</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <scope>provided</scope>
@@ -212,6 +218,14 @@
                 <include>**/Test*.java</include>
                 <include>**/DockerTest*.java</include>
               </includes>
+              <argLine>
+                --add-opens java.base/java.util=ALL-UNNAMED
+                --add-opens java.base/java.lang=ALL-UNNAMED
+                @{jacocoArgLine}
+                -javaagent:${org.mockito:mockito-core:jar}
+                -XX:+EnableDynamicAgentLoading
+                -Xshare:off
+              </argLine>
             </configuration>
           </plugin>
 
@@ -220,6 +234,12 @@
             <artifactId>maven-dependency-plugin</artifactId>
             <version>${plugin.dependency}</version>
             <executions>
+              <execution>
+                <id>properties</id>
+                <goals>
+                  <goal>properties</goal>
+                </goals>
+              </execution>
               <execution>
                 <id>unpack-certs-helper</id>
                 <phase>generate-test-resources</phase>

--- a/jena-fuseki-kafka-module/src/main/java/org/apache/jena/fuseki/kafka/FKRegistry.java
+++ b/jena-fuseki-kafka-module/src/main/java/org/apache/jena/fuseki/kafka/FKRegistry.java
@@ -19,10 +19,13 @@ package org.apache.jena.fuseki.kafka;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListSet;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.kafka.JenaKafkaException;
 import org.apache.jena.kafka.KConnectorDesc;
 
@@ -43,6 +46,7 @@ public class FKRegistry {
 
     // Topic to connector record.
     private final Map<String, KConnectorDesc> topicToConnector = new ConcurrentHashMap<>();
+    private final Set<String> dlqTopics = new ConcurrentSkipListSet<>();
 
     /**
      * Return the {@link KConnectorDesc} for a topic.
@@ -66,9 +70,20 @@ public class FKRegistry {
      * Register a connector binding {@link KConnectorDesc} for the given topic(s)
      */
     public void register(List<String> topics, KConnectorDesc connectorDescriptor) {
+        // Track DLQ topics as we don't allow a DLQ topic to also be an input topic otherwise a malformed message would
+        // put connectors into a DLQ loop
+        if (StringUtils.isNotBlank(connectorDescriptor.getDlqTopic())) {
+            dlqTopics.add(connectorDescriptor.getDlqTopic());
+        }
+
+        // We only permit a single connector per-topic
         for (String topicName : topics) {
             if (topicToConnector.containsKey(topicName)) {
                 throw new JenaKafkaException("Multiple connectors configured for same topic: " + topicName);
+            }
+            if (dlqTopics.contains(topicName)) {
+                throw new JenaKafkaException(
+                        "Can't configure a connector with input topic '" + topicName + "' as this is already a DLQ topic for another connector");
             }
             topicToConnector.put(topicName, connectorDescriptor);
         }
@@ -77,7 +92,10 @@ public class FKRegistry {
     /**
      * Remove all registrations associated with the given topic(s)
      */
-    public void unregister(List<String> topics) {
+    public void unregister(List<String> topics, KConnectorDesc connectorDescriptor) {
+        if (StringUtils.isNotBlank(connectorDescriptor.getDlqTopic())) {
+            dlqTopics.remove(connectorDescriptor.getDlqTopic());
+        }
         for (String topicName : topics) {
             topicToConnector.remove(topicName);
         }

--- a/jena-fuseki-kafka-module/src/main/java/org/apache/jena/fuseki/kafka/FKRegistry.java
+++ b/jena-fuseki-kafka-module/src/main/java/org/apache/jena/fuseki/kafka/FKRegistry.java
@@ -16,10 +16,7 @@
 
 package org.apache.jena.fuseki.kafka;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListSet;
 
@@ -63,7 +60,7 @@ public class FKRegistry {
      * @return Registered connectors
      */
     public Collection<KConnectorDesc> getConnectors() {
-        return topicToConnector.values();
+        return Collections.unmodifiableCollection(topicToConnector.values());
     }
 
     /**
@@ -99,5 +96,13 @@ public class FKRegistry {
         for (String topicName : topics) {
             topicToConnector.remove(topicName);
         }
+    }
+
+    /**
+     * Resets the register, intended only for testing to ensure a blank slate
+     */
+    void reset() {
+        topicToConnector.clear();
+        dlqTopics.clear();
     }
 }

--- a/jena-fuseki-kafka-module/src/main/java/org/apache/jena/fuseki/kafka/FKS.java
+++ b/jena-fuseki-kafka-module/src/main/java/org/apache/jena/fuseki/kafka/FKS.java
@@ -146,6 +146,27 @@ public class FKS {
         return dap.getDataService();
     }
 
+    /**
+     * Find the connectors referring to the dataset and return the list of topics feeding into this dataset. This can be
+     * the empty list.
+     * <p>
+     * This is primarily intended for use by extensions that build atop this module as it allows additional services to
+     * discover the configured Kafka topic(s) for a given dataset and act upon those as needed.
+     * </p>
+     */
+    @SuppressWarnings("unused")
+    public static List<String> findTopics(String uriPath) {
+        uriPath = DataAccessPoint.canonical(uriPath);
+        List<String> topics = new ArrayList<>();
+        for (KConnectorDesc fkConn : FKRegistry.get().getConnectors()) {
+            String dispatchURI = fkConn.getDatasetName();
+            if (dispatchURI.startsWith(uriPath)) {
+                topics.addAll(fkConn.getTopics());
+            }
+        }
+        return Collections.unmodifiableList(topics);
+    }
+
     private static ExecutorService EXECUTOR = threadExecutor();
 
     private static ExecutorService threadExecutor() {

--- a/jena-fuseki-kafka-module/src/main/java/org/apache/jena/fuseki/kafka/FMod_FusekiKafka.java
+++ b/jena-fuseki-kafka-module/src/main/java/org/apache/jena/fuseki/kafka/FMod_FusekiKafka.java
@@ -135,8 +135,8 @@ public class FMod_FusekiKafka implements FusekiAutoModule {
         FKRegistry.get().register(conn.getTopics(), conn);
     }
 
-    private List<Pair<KConnectorDesc, FusekiOffsetStore>> connectors() {
-        return buildState.get();
+    List<Pair<KConnectorDesc, FusekiOffsetStore>> connectors() {
+        return Collections.unmodifiableList(buildState.get());
     }
 
     /**
@@ -215,7 +215,7 @@ public class FMod_FusekiKafka implements FusekiAutoModule {
             }
             connectors.forEach(pair -> {
                 KConnectorDesc conn = pair.getLeft();
-                FKRegistry.get().unregister(conn.getTopics());
+                FKRegistry.get().unregister(conn.getTopics(), conn);
             });
 
             // Reset the poll threads otherwise they would continue running infinitely

--- a/jena-fuseki-kafka-module/src/test/java/org/apache/jena/fuseki/kafka/TestConfig.java
+++ b/jena-fuseki-kafka-module/src/test/java/org/apache/jena/fuseki/kafka/TestConfig.java
@@ -6,6 +6,7 @@ import org.apache.jena.fuseki.main.sys.FusekiModules;
 import org.apache.jena.fuseki.system.FusekiLogging;
 import org.apache.jena.sys.JenaSystem;
 import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.util.concurrent.atomic.AtomicReference;
@@ -15,6 +16,11 @@ public class TestConfig {
     static {
         JenaSystem.init();
         FusekiLogging.markInitialized(true);
+    }
+
+    @BeforeClass
+    public void setup() {
+        FKRegistry.get().reset();
     }
 
     @Test

--- a/jena-fuseki-kafka-module/src/test/java/org/apache/jena/fuseki/kafka/TestFKRegistry.java
+++ b/jena-fuseki-kafka-module/src/test/java/org/apache/jena/fuseki/kafka/TestFKRegistry.java
@@ -11,6 +11,7 @@ import org.testng.annotations.Test;
 import java.util.List;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class TestFKRegistry {
 
@@ -31,7 +32,22 @@ public class TestFKRegistry {
             Assert.assertEquals(FKRegistry.get().getConnectorDescriptor(KafkaTestCluster.DEFAULT_TOPIC), conn);
             FKRegistry.get().register(topics, conn);
         } finally {
-            FKRegistry.get().unregister(topics);
+            FKRegistry.get().unregister(topics, conn);
         }
+    }
+
+    @Test(expectedExceptions = JenaKafkaException.class, expectedExceptionsMessageRegExp = ".*DLQ topic.*")
+    public void givenDlqLoop_whenRegistering_thenError() {
+        // Given
+        KConnectorDesc conn1 = mock(KConnectorDesc.class);
+        when(conn1.getDlqTopic()).thenReturn("b");
+        List<String> topics1 = List.of("a");
+        KConnectorDesc conn2 = mock(KConnectorDesc.class);
+        when(conn2.getDlqTopic()).thenReturn("a");
+        List<String> topics2 = List.of("b");
+
+        // When and Then
+        FKRegistry.get().register(topics1, conn1);
+        FKRegistry.get().register(topics2, conn2);
     }
 }

--- a/jena-fuseki-kafka-module/src/test/java/org/apache/jena/fuseki/kafka/TestFKRegistry.java
+++ b/jena-fuseki-kafka-module/src/test/java/org/apache/jena/fuseki/kafka/TestFKRegistry.java
@@ -6,6 +6,8 @@ import org.apache.jena.kafka.JenaKafkaException;
 import org.apache.jena.kafka.KConnectorDesc;
 import org.apache.jena.sys.JenaSystem;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.util.List;
@@ -18,6 +20,16 @@ public class TestFKRegistry {
     static {
         JenaSystem.init();
         FusekiLogging.markInitialized(true);
+    }
+
+    @BeforeClass
+    public void setup() {
+        FKRegistry.get().reset();
+    }
+
+    @AfterClass
+    public void teardown() {
+        FKRegistry.get().reset();
     }
 
     @Test(expectedExceptions = JenaKafkaException.class, expectedExceptionsMessageRegExp = "Multiple connectors.*")

--- a/jena-fuseki-kafka-module/src/test/java/org/apache/jena/fuseki/kafka/TestFMod_FusekiKafka.java
+++ b/jena-fuseki-kafka-module/src/test/java/org/apache/jena/fuseki/kafka/TestFMod_FusekiKafka.java
@@ -1,0 +1,40 @@
+package org.apache.jena.fuseki.kafka;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.jena.fuseki.main.FusekiServer;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.Set;
+
+public class TestFMod_FusekiKafka {
+
+    private FMod_FusekiKafka createInstance() {
+        return new FMod_FusekiKafka();
+    }
+
+    @Test
+    public void givenModule_whenQueryingName_thenNotBlank() {
+        // Given
+        FMod_FusekiKafka module = createInstance();
+
+        // When
+        String name = module.name();
+
+        // Then
+        Assert.assertFalse(StringUtils.isBlank(name));
+    }
+
+    @Test
+    public void givenModule_whenPreparingWithNoConfigModel_thenNothingToDo() {
+        // Given
+        FMod_FusekiKafka module = createInstance();
+
+        // When
+        module.prepare(Mockito.mock(FusekiServer.Builder.class), Set.of("test"), null);
+
+        // Then
+        Assert.assertTrue(module.connectors().isEmpty());
+    }
+}

--- a/jena-fuseki-kafka-module/src/test/resources/logback-test.xml
+++ b/jena-fuseki-kafka-module/src/test/resources/logback-test.xml
@@ -18,7 +18,7 @@
     <!-- Kafka's NetworkClient is very chatty! -->
     <logger name="org.apache.kafka.clients.NetworkClient" level="ERROR" />
 
-    <root level="INFO">
+    <root level="OFF">
         <appender-ref ref="STDERR" />
     </root>
 </configuration>

--- a/jena-kafka-connector/pom.xml
+++ b/jena-kafka-connector/pom.xml
@@ -210,6 +210,20 @@
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <version>${plugin.dependency}</version>
+                        <executions>
+                            <execution>
+                                <id>properties</id>
+                                <goals>
+                                    <goal>properties</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <includes>
@@ -218,6 +232,14 @@
                             </includes>
                             <reuseForks>false</reuseForks>
                             <forkCount>${test.maxForks}</forkCount>
+                            <argLine>
+                                --add-opens java.base/java.util=ALL-UNNAMED
+                                --add-opens java.base/java.lang=ALL-UNNAMED
+                                @{jacocoArgLine}
+                                -javaagent:${org.mockito:mockito-core:jar}
+                                -XX:+EnableDynamicAgentLoading
+                                -Xshare:off
+                            </argLine>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/jena-kafka-connector/src/main/java/org/apache/jena/kafka/KConnectorDesc.java
+++ b/jena-kafka-connector/src/main/java/org/apache/jena/kafka/KConnectorDesc.java
@@ -69,6 +69,10 @@ public class KConnectorDesc {
             throw new IllegalArgumentException("topics cannot be empty");
         }
         this.dlqTopic = dlqTopic;
+        if (StringUtils.isNotBlank(this.dlqTopic) && this.topics.contains(this.dlqTopic)) {
+            throw new JenaKafkaException(
+                    "Can't configure the DLQ topic as " + this.dlqTopic + " as this is also an input topic!");
+        }
         this.bootstrapServers = Objects.requireNonNull(bootstrapServers, "bootstrapServers cannot be null");
         this.datasetName = datasetName;
         this.syncTopic = syncTopic;

--- a/jena-kafka-connector/src/main/java/org/apache/jena/kafka/KafkaConnectorAssembler.java
+++ b/jena-kafka-connector/src/main/java/org/apache/jena/kafka/KafkaConnectorAssembler.java
@@ -55,7 +55,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Assembler for a Fuseki-Kafka connector that takes Kafka events and executes them on a Fuseki server.
  * <p>
- * The Kafka event has a header "Content-type" and acts the same as HTTP.
+ * The Kafka event has a header "Content-type" which is used to detect the incoming event format.
  * <p>
  * This is an update stream, not publishing data to Kafka.
  * <p>
@@ -70,6 +70,11 @@ import org.slf4j.LoggerFactory;
  *
  *   # Kafka topic
  *   fk:topic               "RDF";
+ *   # May be multiple topics e.g.
+ *   # fk:topic             "Other";
+ *
+ *   # Optional DLQ Topic to which malformed events are sent
+ *   # fk:dlqTopic          "dlq";
  *
  *   # File used to track the state (the last offset processes)
  *   # Used across Fuseki restarts.

--- a/jena-kafka-connector/src/main/java/org/apache/jena/kafka/KafkaConnectorAssembler.java
+++ b/jena-kafka-connector/src/main/java/org/apache/jena/kafka/KafkaConnectorAssembler.java
@@ -171,9 +171,6 @@ public class KafkaConnectorAssembler extends AssemblerBase implements Assembler 
          *
          *     ## false means replay from the start (ignore sync)
          *     fk:replayTopic       false;
-         *
-         *     ## Relay to a remote triplestore.
-         *     fk:remoteEndpoint    "http://host/triplestore";
          *     .
          */
 

--- a/jena-kafka-connector/src/main/java/org/apache/jena/kafka/common/FusekiSink.java
+++ b/jena-kafka-connector/src/main/java/org/apache/jena/kafka/common/FusekiSink.java
@@ -23,10 +23,14 @@ import org.apache.kafka.common.utils.Bytes;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 @ToString
-public class FusekiSink implements Sink<Event<Bytes, RdfPayload>> {
+public class FusekiSink<T extends DatasetGraph> implements Sink<Event<Bytes, RdfPayload>> {
 
+    /**
+     * The dataset this sink is writing to
+     */
     @NonNull
-    private final DatasetGraph dataset;
+    @ToString.Exclude
+    protected final T dataset;
 
     @Override
     public final void send(Event<Bytes, RdfPayload> event) {

--- a/jena-kafka-connector/src/test/files/bad-assem-dlq-topic-also-input-topic.ttl
+++ b/jena-kafka-connector/src/test/files/bad-assem-dlq-topic-also-input-topic.ttl
@@ -1,0 +1,15 @@
+PREFIX fuseki:  <http://jena.apache.org/fuseki#>
+PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX fk:      <http://jena.apache.org/fuseki/kafka#>
+
+# Malformed - string property specified as wrong type
+
+<#connector> rdf:type fk:Connector ;
+    fk:bootstrapServers    "localhost:9092";
+    fk:topic               "RDF0";
+    fk:fusekiServiceName   "/ds1";
+    fk:syncTopic           true;
+    # BAD - DLQ topic can't be an input topic!
+    fk:dlqTopic            "RDF0";
+    fk:stateFile           "1.state";
+    .

--- a/jena-kafka-connector/src/test/java/org/apache/jena/kafka/TestKafkaConnectorAssembler.java
+++ b/jena-kafka-connector/src/test/java/org/apache/jena/kafka/TestKafkaConnectorAssembler.java
@@ -54,7 +54,8 @@ public class TestKafkaConnectorAssembler {
             "bad-assem-multi-value-boolean-property.ttl",
             "bad-assem-mistyped-string-property.ttl",
             "bad-assem-mistyped-boolean-property.ttl",
-            "bad-assem-mistyped-mandatory-string-property.ttl"
+            "bad-assem-mistyped-mandatory-string-property.ttl",
+            "bad-assem-dlq-topic-also-input-topic.ttl"
     })
     @ParameterizedTest
     public void givenMalformedConfig_whenAssemblingConnector_thenNotLoaded(String filename) {

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <test.maxForks>2</test.maxForks>
 
         <!-- Maven Plugin versions -->
-        <plugin.clean>3.4.1</plugin.clean>
+        <plugin.clean>3.5.0</plugin.clean>
         <plugin.compiler>3.14.0</plugin.compiler>
         <plugin.cyclonedx>2.9.1</plugin.cyclonedx>
         <plugin.dependency>3.8.1</plugin.dependency>
@@ -86,25 +86,26 @@
 
         <!-- Internal dependencies -->
         <dependency.jena>5.4.0</dependency.jena>
-        <dependency.smart-caches>0.29.0</dependency.smart-caches>
+        <dependency.smart-caches>0.29.1</dependency.smart-caches>
 
         <!-- External dependencies -->
+        <dependency.commons-beanutils>1.11.0</dependency.commons-beanutils>
         <dependency.commons-io>2.19.0</dependency.commons-io>
         <dependency.commons-lang>3.17.0</dependency.commons-lang>
-        <dependency.kafka>3.9.0</dependency.kafka>
+        <dependency.kafka>3.9.1</dependency.kafka>
         <dependency.log4j2>2.24.3</dependency.log4j2>
         <dependency.lombok>1.18.38</dependency.lombok>
         <dependency.servlet>6.1.0</dependency.servlet>
-        <dependency.slf4j>2.0.7</dependency.slf4j>
+        <dependency.slf4j>2.0.17</dependency.slf4j>
 
         <!-- Test dependencies -->
         <dependency.awaitility>4.3.0</dependency.awaitility>
-        <dependency.junit5>5.12.2</dependency.junit5>
+        <dependency.junit5>5.13.1</dependency.junit5>
         <dependency.junit5-platform>1.10.1</dependency.junit5-platform>
         <dependency.logback>1.5.18</dependency.logback>
         <dependency.log4j2>2.24.3</dependency.log4j2>
         <dependency.mockito>5.18.0</dependency.mockito>
-        <dependency.testcontainers>1.21.0</dependency.testcontainers>
+        <dependency.testcontainers>1.21.1</dependency.testcontainers>
         <dependency.testng>7.11.0</dependency.testng>
 
     </properties>
@@ -178,6 +179,18 @@
                 <groupId>org.apache.jena</groupId>
                 <artifactId>jena-fuseki-main</artifactId>
                 <version>${dependency.jena}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-beanutils</groupId>
+                        <artifactId>commons-beanutils</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>commons-beanutils</groupId>
+                <artifactId>commons-beanutils</artifactId>
+                <version>${dependency.commons-beanutils}</version>
             </dependency>
 
             <!-- The combined jar for Fuseki main -->

--- a/release-setup
+++ b/release-setup
@@ -7,8 +7,8 @@
 ## Revert:
 ##    mvn versions:set -DnewVersion=???-SNAPSHOT
 
-export VER=1.5.2
-VER_NEXT=1.5.3-SNAPSHOT
+export VER=2.0.0
+VER_NEXT=2.0.1-SNAPSHOT
 TAG="v$VER"
 
 ## Set release and next version.


### PR DESCRIPTION
This PR makes various minor bug fixes, improvements and documentation changes in support of upgrading telicent-io/smart-cache-graph onto the 2.x release line of Fuseki Kafka.  These changes represent things that were causing issues during the code migration.  Once these changes are merged I can release Fuseki Kafka 2.0.0 and get the PR for the SCG upgrade out for review.