### PR TITLE
Fix for potential NPEs (CORE-834)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Kafka Connector for Apache Jena Fuseki
 
+## 2.0.1
+
+- Fixed a bug where old 1.x configurations that used full endpoint URIs, e.g. `/ds/upload`, for their connector
+  `fk:fusekiServiceName` properties, as opposed to simple service names, i.e. `/ds`, would not successfully start. These
+  service names should now successfully permit startup with a warning that support for full endpoint URIs in
+  configuration will be removed in the future.
+- Fixed a couple of cases where a NPE could be thrown during startup without an accompanying descriptive error
+
 ## 2.0.0
 
 This is a major version with significant breaking changes versus the 1.x releases.  These changes have been motivated by

--- a/jena-fuseki-kafka-module/src/test/java/org/apache/jena/fuseki/kafka/DockerTestFK.java
+++ b/jena-fuseki-kafka-module/src/test/java/org/apache/jena/fuseki/kafka/DockerTestFK.java
@@ -134,7 +134,8 @@ public class DockerTestFK {
 
             // When
             FusekiOffsetStore newOffsets = FusekiOffsetStore.builder().datasetName(DSG_NAME).build();
-            newOffsets.saveOffset(KafkaEventSource.externalOffsetStoreKey(KafkaTestCluster.DEFAULT_TOPIC, 0, "test"), 0L);
+            newOffsets.saveOffset(KafkaEventSource.externalOffsetStoreKey(KafkaTestCluster.DEFAULT_TOPIC, 0, "test"),
+                                  0L);
             FKS.restoreOffsetForDataset(DSG_NAME, newOffsets);
 
             // Then
@@ -158,7 +159,8 @@ public class DockerTestFK {
             DSG.clear();
             DockerTestConfigFK.waitForDataCount(URL, 0);
             FusekiOffsetStore newOffsets = FusekiOffsetStore.builder().datasetName(DSG_NAME).build();
-            newOffsets.saveOffset(KafkaEventSource.externalOffsetStoreKey(KafkaTestCluster.DEFAULT_TOPIC, 0, "test"), 2L);
+            newOffsets.saveOffset(KafkaEventSource.externalOffsetStoreKey(KafkaTestCluster.DEFAULT_TOPIC, 0, "test"),
+                                  2L);
             FKS.restoreOffsetForDataset("", newOffsets);
 
             // Then
@@ -180,7 +182,8 @@ public class DockerTestFK {
             DSG.clear();
             DockerTestConfigFK.waitForDataCount(URL, 0);
             FusekiOffsetStore newOffsets = FusekiOffsetStore.builder().datasetName(DSG_NAME).build();
-            newOffsets.saveOffset(KafkaEventSource.externalOffsetStoreKey(KafkaTestCluster.DEFAULT_TOPIC, 0, "test"), -5L);
+            newOffsets.saveOffset(KafkaEventSource.externalOffsetStoreKey(KafkaTestCluster.DEFAULT_TOPIC, 0, "test"),
+                                  -5L);
             FKS.restoreOffsetForDataset("", newOffsets);
 
             // Then
@@ -203,5 +206,21 @@ public class DockerTestFK {
         FKS.addConnectorToServer(conn, server, offsets, null);
         server.start();
         return server;
+    }
+
+    @Test(expectedExceptions = FusekiKafkaException.class, expectedExceptionsMessageRegExp = "No dataset found.*")
+    public void givenMisconfiguredDatasetName_whenAddingConnectorToServer_thenFails() {
+        // Given
+        KConnectorDesc conn =
+                new KConnectorDesc(List.of(KafkaTestCluster.DEFAULT_TOPIC), this.kafka.getBootstrapServers(), "/wrong",
+                                   null, false, true, null, consumerProps());
+        FusekiServer server = FusekiServer.create()
+                                          .port(0)
+                                          .fusekiModules(FusekiModules.create(new FMod_FusekiKafka()))
+                                          .add(DSG_NAME, DSG).build();
+        FusekiOffsetStore offsets = FusekiOffsetStore.builder().datasetName(DSG_NAME).build();
+
+        // When and Then
+        FKS.addConnectorToServer(conn, server, offsets, null);
     }
 }

--- a/jena-fuseki-kafka-module/src/test/java/org/apache/jena/fuseki/kafka/TestFKS.java
+++ b/jena-fuseki-kafka-module/src/test/java/org/apache/jena/fuseki/kafka/TestFKS.java
@@ -1,14 +1,23 @@
 package org.apache.jena.fuseki.kafka;
 
+import lombok.Data;
+import org.apache.commons.collections4.MultiValuedMap;
+import org.apache.commons.collections4.multimap.HashSetValuedHashMap;
 import org.apache.jena.fuseki.main.FusekiServer;
+import org.apache.jena.fuseki.server.DataAccessPoint;
 import org.apache.jena.fuseki.server.DataAccessPointRegistry;
 import org.apache.jena.fuseki.server.DataService;
+import org.apache.jena.fuseki.server.DispatchFunction;
 import org.apache.jena.fuseki.system.FusekiLogging;
+import org.apache.jena.sparql.algebra.Op;
 import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.core.DatasetGraphFactory;
 import org.apache.jena.sys.JenaSystem;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -22,8 +31,8 @@ public class TestFKS {
         FusekiLogging.markInitialized(true);
     }
 
-    @Test
-    public void givenEmptyDapRegistry_whenFindingDataset_thenNull() {
+    @Test(dataProvider = "paths")
+    public void givenEmptyDapRegistry_whenFindingDataset_thenNull(String path) {
         // Given
         DataAccessPointRegistry registry = mock(DataAccessPointRegistry.class);
         when(registry.get(any(String.class))).thenReturn(null);
@@ -31,9 +40,38 @@ public class TestFKS {
         when(server.getDataAccessPointRegistry()).thenReturn(registry);
 
         // When
-        Optional<DatasetGraph> dsg = FKS.findDataset(server, "/ds");
+        Optional<DatasetGraph> dsg = FKS.findDataset(server, path);
 
         // Then
         Assert.assertFalse(dsg.isPresent());
+    }
+
+    @DataProvider(name = "paths")
+    private Object[][] paths() {
+        return new Object[][] {
+                { "/ds" },
+                { "/ds/" },
+                { "/ds/upload" },
+                { "/ds/upload/"}
+        };
+    }
+
+    @Test(dataProvider = "paths")
+    public void givenNonEmptyDapRegistry_whenFindingDataset_thenFound(String path) {
+        // Given
+        DatasetGraph dsg = DatasetGraphFactory.empty();
+        DataAccessPointRegistry registry = new  DataAccessPointRegistry();
+        DataService service = mock(DataService.class);
+        when(service.getDataset()).thenReturn(dsg);
+        registry.register(new DataAccessPoint("ds", service));
+        FusekiServer server = mock(FusekiServer.class);
+        when(server.getDataAccessPointRegistry()).thenReturn(registry);
+
+        // When
+        Optional<DatasetGraph> found = FKS.findDataset(server, path);
+
+        // Then
+        Assert.assertTrue(found.isPresent());
+        Assert.assertEquals(found.get(), dsg);
     }
 }

--- a/jena-kafka-connector/src/main/java/org/apache/jena/kafka/KafkaConnectorAssembler.java
+++ b/jena-kafka-connector/src/main/java/org/apache/jena/kafka/KafkaConnectorAssembler.java
@@ -97,7 +97,7 @@ public class KafkaConnectorAssembler extends AssemblerBase implements Assembler 
     // Preferred:   "fusekiServiceName"
 
     /**
-     * Destination dataset and endpoint for dispatching Kafka events.
+     * Destination dataset for dispatching Kafka events.
      */
     public static Node pFusekiServiceName = NodeFactory.createURI(NS + "fusekiServiceName");
     /*

--- a/jena-kafka-connector/src/main/java/org/apache/jena/kafka/common/FusekiProjector.java
+++ b/jena-kafka-connector/src/main/java/org/apache/jena/kafka/common/FusekiProjector.java
@@ -115,10 +115,10 @@ public class FusekiProjector implements StallAwareProjector<Event<Bytes, RdfPayl
     @Builder
     private FusekiProjector(KConnectorDesc connector, EventSource<Bytes, RdfPayload> source, DatasetGraph dataset,
                             long batchSize, Duration maxTransactionDuration, Sink<Event<Bytes, RdfPayload>> dlq) {
-        this.connector = Objects.requireNonNull(connector);
+        this.connector = Objects.requireNonNull(connector, "Kafka Connector descriptor cannot be null");
         this.topicNames = StringUtils.join(this.connector.getTopics(), ", ");
-        this.source = Objects.requireNonNull(source);
-        this.dataset = Objects.requireNonNull(dataset);
+        this.source = Objects.requireNonNull(source, "Event Source cannot be null");
+        this.dataset = Objects.requireNonNull(dataset, "Dataset cannot be null");
         this.batchSize = batchSize > 0 ? batchSize : DEFAULT_BATCH_SIZE;
         this.maxTransactionDuration = isValidDuration(maxTransactionDuration) ? maxTransactionDuration :
                                       DEFAULT_MAX_TRANSACTION_DURATION;

--- a/pom.xml
+++ b/pom.xml
@@ -175,6 +175,12 @@
                 <groupId>org.apache.jena</groupId>
                 <artifactId>jena-fuseki-core</artifactId>
                 <version>${dependency.jena}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.commons</groupId>
+                        <artifactId>commons-fileupload2-core</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Allow for older style full endpoint configuration as `fk:fusekiServiceName` which wasn't permitted in 2.0.0.  As this was an unitentional breaking change from the 1.x module this has been restored with a logged warning that such configuration will be disallowed in future.