### PR TITLE
Minor fixes and upgraded dependencies (CORE-834)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Kafka Connector for Apache Jena Fuseki
 
+## 2.0.2
+
+- Fixed a bug where upgrading legacy state files caused Kafka offsets to be off by 1 resulting in re-processing an event
+  from the input topic
+- Picked up a fix for Kafka polling where long transaction lock waits (caused by interactions with external code) could
+  lead to Kafka polling threads failing prematurely.  These threads will now auto-recover in this scenario.
+- Build and Dependency Updates:
+    - Switched to new Maven Central publishing process
+    - Apache Commons IO upgraded to 2.20.0
+    - Apache Commons Lang upgraded to 3.18.0
+    - Apache Jena upgraded to 5.5.0
+    - Log4j upgraded to 2.25.1
+    - Smart Caches Core upgraded to 0.29.2
+    - Various build and test dependencies upgraded to latest available
+
 ## 2.0.1
 
 - Fixed a bug where old 1.x configurations that used full endpoint URIs, e.g. `/ds/upload`, for their connector

--- a/jena-fuseki-kafka-module/pom.xml
+++ b/jena-fuseki-kafka-module/pom.xml
@@ -22,7 +22,7 @@
   <artifactId>jena-fuseki-kafka-module</artifactId>
   <packaging>jar</packaging>
   <description>Apache Jena Fuseki module for Kafka connector</description>
-  <name>Jena-Kafka : Fuseki-Kafka Connector</name>
+  <name>Jena-Kafka : Fuseki-Kafka Module</name>
 
   <parent>
     <groupId>io.telicent.jena</groupId>

--- a/jena-fuseki-kafka-module/src/main/java/org/apache/jena/fuseki/kafka/FKS.java
+++ b/jena-fuseki-kafka-module/src/main/java/org/apache/jena/fuseki/kafka/FKS.java
@@ -37,7 +37,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.atlas.logging.FmtLog;
 import org.apache.jena.fuseki.main.FusekiServer;
 import org.apache.jena.fuseki.server.*;
-import org.apache.jena.kafka.FusekiKafka;
 import org.apache.jena.kafka.KConnectorDesc;
 import org.apache.jena.kafka.common.FusekiOffsetStore;
 import org.apache.jena.kafka.common.FusekiProjector;

--- a/jena-fuseki-kafka-module/src/test/java/org/apache/jena/fuseki/kafka/DockerTestKafkaDelays.java
+++ b/jena-fuseki-kafka-module/src/test/java/org/apache/jena/fuseki/kafka/DockerTestKafkaDelays.java
@@ -15,7 +15,6 @@ import org.apache.jena.sys.JenaSystem;
 import org.apache.jena.system.G;
 import org.apache.jena.vocabulary.RDF;
 import org.apache.kafka.clients.admin.AdminClient;
-import org.apache.kafka.clients.admin.CreateTopicsResult;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.testcontainers.containers.KafkaContainer;
@@ -33,9 +32,6 @@ import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.apache.jena.fuseki.kafka.DockerTestConfigFK.configuration;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.AssertJUnit.assertEquals;
-import static org.testng.AssertJUnit.assertTrue;
 
 
 public class DockerTestKafkaDelays {

--- a/jena-fuseki-kafka-module/src/test/java/org/apache/jena/fuseki/kafka/TestFKS.java
+++ b/jena-fuseki-kafka-module/src/test/java/org/apache/jena/fuseki/kafka/TestFKS.java
@@ -1,15 +1,10 @@
 package org.apache.jena.fuseki.kafka;
 
-import lombok.Data;
-import org.apache.commons.collections4.MultiValuedMap;
-import org.apache.commons.collections4.multimap.HashSetValuedHashMap;
 import org.apache.jena.fuseki.main.FusekiServer;
 import org.apache.jena.fuseki.server.DataAccessPoint;
 import org.apache.jena.fuseki.server.DataAccessPointRegistry;
 import org.apache.jena.fuseki.server.DataService;
-import org.apache.jena.fuseki.server.DispatchFunction;
 import org.apache.jena.fuseki.system.FusekiLogging;
-import org.apache.jena.sparql.algebra.Op;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.DatasetGraphFactory;
 import org.apache.jena.sys.JenaSystem;
@@ -17,7 +12,6 @@ import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import java.util.Collections;
 import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;

--- a/jena-fuseki-kafka-module/src/test/java/org/apache/jena/fuseki/kafka/TestPollMonitor.java
+++ b/jena-fuseki-kafka-module/src/test/java/org/apache/jena/fuseki/kafka/TestPollMonitor.java
@@ -1,0 +1,120 @@
+package org.apache.jena.fuseki.kafka;
+
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.*;
+
+public class TestPollMonitor {
+
+    private ExecutorService executor;
+
+    @BeforeMethod
+    public void freshExecutor() {
+        if (this.executor != null) {
+            this.executor.shutdownNow();
+        }
+        this.executor = Executors.newCachedThreadPool();
+    }
+
+    @AfterMethod
+    public void cleanup() {
+        this.executor.shutdownNow();
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void givenNullThreadsToMonitor_whenCreatingMonitor_thenNPE() {
+        // Given, When and Then
+        new FKS.PollThreadMonitor(null, 3);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void givenNegativeCheckInterval_whenCreatingMonitor_thenIllegalArgument() {
+        // Given, When and Then
+        new FKS.PollThreadMonitor(Collections.emptyList(), -1);
+    }
+
+    private static final class Sleepy implements Runnable {
+
+        @Override
+        public void run() {
+            try {
+                Thread.sleep(Long.MAX_VALUE);
+            } catch (InterruptedException e) {
+                return;
+            }
+        }
+    }
+
+    private static final class Breaky implements Runnable {
+        @Override
+        public void run() {
+            throw new RuntimeException("Breaks");
+        }
+    }
+
+    private static final class Completey implements Runnable {
+        @Override
+        public void run() {
+            return;
+        }
+    }
+
+    @Test
+    public void givenThreadsToMonitor_whenRunningPollMonitor_thenMonitored_andCanBePromptlyCancelled() throws
+            InterruptedException {
+        // Given
+        List<Future<?>> futures = new ArrayList<>();
+        futures.add(executor.submit(new Sleepy()));
+        futures.add(executor.submit(new Breaky()));
+        futures.add(executor.submit(new Completey()));
+
+        // When
+        FKS.PollThreadMonitor monitor = new FKS.PollThreadMonitor(futures, 1);
+        Future<?> f = executor.submit(monitor);
+
+        // Then
+        verifyMonitorStillRunning(f);
+
+        // And
+        verifyPromptCancellation(monitor, f);
+    }
+
+    private static void verifyMonitorStillRunning(Future<?> f) {
+        Assert.assertThrows("Monitor thread should be running", TimeoutException.class,
+                            () -> f.get(3, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void givenCancelledThreadsToMonitor_whenRunningPollMonitor_thenMonitored_andCanBePromptlyCancelled() throws
+            InterruptedException {
+        // Given
+        List<Future<?>> futures = new ArrayList<>();
+        futures.add(executor.submit(new Sleepy()));
+        futures.add(executor.submit(new Breaky()));
+        for (Future<?> f : futures) {
+            f.cancel(true);
+        }
+
+        // When
+        FKS.PollThreadMonitor monitor = new FKS.PollThreadMonitor(futures, 1);
+        Future<?> f = executor.submit(monitor);
+
+        // Then
+        verifyMonitorStillRunning(f);
+
+        // And
+        verifyPromptCancellation(monitor, f);
+    }
+
+    private static void verifyPromptCancellation(FKS.PollThreadMonitor monitor, Future<?> future) throws InterruptedException {
+        monitor.cancel();
+        Thread.sleep(100);
+        Assert.assertTrue(future.isDone());
+    }
+}

--- a/jena-kafka-connector/src/test/java/org/apache/jena/kafka/common/DockerTestFusekiProjectorTdb2.java
+++ b/jena-kafka-connector/src/test/java/org/apache/jena/kafka/common/DockerTestFusekiProjectorTdb2.java
@@ -2,7 +2,6 @@ package org.apache.jena.kafka.common;
 
 import org.apache.jena.dboe.base.file.Location;
 import org.apache.jena.sparql.core.DatasetGraph;
-import org.apache.jena.sparql.core.DatasetGraphFactory;
 import org.apache.jena.tdb2.TDB2Factory;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;

--- a/jena-kafka-connector/src/test/java/org/apache/jena/kafka/common/TestFusekiOffsetStore.java
+++ b/jena-kafka-connector/src/test/java/org/apache/jena/kafka/common/TestFusekiOffsetStore.java
@@ -3,10 +3,8 @@ package org.apache.jena.kafka.common;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.telicent.smart.cache.sources.kafka.KafkaEventSource;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.jena.kafka.FusekiKafka;
 import org.apache.jena.kafka.JenaKafkaException;
 import org.apache.jena.sys.JenaSystem;
-import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -69,7 +67,10 @@ public class TestFusekiOffsetStore {
 
         // Then
         Assertions.assertEquals(datasetName, store.getDatasetName());
-        Assertions.assertTrue(store.hasOffset(KafkaEventSource.externalOffsetStoreKey("test", 0, "example")));
+        String key = KafkaEventSource.externalOffsetStoreKey("test", 0, "example");
+        Assertions.assertTrue(store.hasOffset(key));
+        Assertions.assertEquals(1235L, (Long) store.loadOffset(key),
+                                "Legacy state file offsets were off by 1 so upgrading should correct that");
     }
 
     @Test

--- a/jena-kafka-connector/src/test/java/org/apache/jena/kafka/common/TestFusekiOffsetStore.java
+++ b/jena-kafka-connector/src/test/java/org/apache/jena/kafka/common/TestFusekiOffsetStore.java
@@ -2,6 +2,7 @@ package org.apache.jena.kafka.common;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.telicent.smart.cache.sources.kafka.KafkaEventSource;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.kafka.FusekiKafka;
 import org.apache.jena.kafka.JenaKafkaException;
 import org.apache.jena.sys.JenaSystem;
@@ -69,6 +70,29 @@ public class TestFusekiOffsetStore {
         // Then
         Assertions.assertEquals(datasetName, store.getDatasetName());
         Assertions.assertTrue(store.hasOffset(KafkaEventSource.externalOffsetStoreKey("test", 0, "example")));
+    }
+
+    @Test
+    public void givenLegacyStateFileWithMisMatchedDatasetName_whenCreatingStore_thenConversionFails() throws
+            IOException {
+        // Given
+        String datasetName = DATASET_NAME;
+        Map<String, Object> legacyState = Map.of(FusekiOffsetStore.FIELD_DATASET, datasetName + "/upload",
+                                                 FusekiOffsetStore.LEGACY_FIELD_ENDPOINT, "foo",
+                                                 FusekiOffsetStore.LEGACY_FIELD_TOPIC, "test",
+                                                 FusekiOffsetStore.LEGACY_FIELD_OFFSET, 1234L);
+        File stateFile = createStateFile(legacyState);
+
+        // When and Then
+        JenaKafkaException e = Assertions.assertThrows(JenaKafkaException.class, () -> FusekiOffsetStore.builder()
+                                                                                                        .datasetName(
+                                                                                                                datasetName)
+                                                                                                        .stateFile(
+                                                                                                                stateFile)
+                                                                                                        .consumerGroup(
+                                                                                                                "example")
+                                                                                                        .build());
+        Assertions.assertTrue(StringUtils.contains(e.getMessage(), "Dataset name does not match"));
     }
 
     private File createStateFile(Map<String, Object> state) throws IOException {
@@ -196,6 +220,6 @@ public class TestFusekiOffsetStore {
         // Then
         Assertions.assertNotEquals(0, copy.length());
         FusekiOffsetStore copied = FusekiOffsetStore.builder().datasetName(DATASET_NAME).stateFile(copy).build();
-        Assertions.assertEquals(1234L, (Long)copied.loadOffset("test"));
+        Assertions.assertEquals(1234L, (Long) copied.loadOffset("test"));
     }
 }

--- a/jena-kafka-connector/src/test/java/org/apache/jena/kafka/common/TestFusekiProjector.java
+++ b/jena-kafka-connector/src/test/java/org/apache/jena/kafka/common/TestFusekiProjector.java
@@ -27,7 +27,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 
-import javax.xml.crypto.Data;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <plugin.cyclonedx>2.9.1</plugin.cyclonedx>
         <plugin.dependency>3.8.1</plugin.dependency>
         <plugin.deploy>3.1.4</plugin.deploy>
-        <plugin.enforcer>3.6.0</plugin.enforcer>
+        <plugin.enforcer>3.6.1</plugin.enforcer>
         <plugin.exec>3.5.1</plugin.exec>
         <plugin.gpg>3.2.8</plugin.gpg>
         <plugin.install>3.1.4</plugin.install>
@@ -85,12 +85,12 @@
         <plugin.surefire>3.5.3</plugin.surefire>
 
         <!-- Internal dependencies -->
-        <dependency.jena>5.4.0</dependency.jena>
-        <dependency.smart-caches>0.29.1</dependency.smart-caches>
+        <dependency.jena>5.5.0</dependency.jena>
+        <dependency.smart-caches>0.29.2</dependency.smart-caches>
 
         <!-- External dependencies -->
         <dependency.commons-beanutils>1.11.0</dependency.commons-beanutils>
-        <dependency.commons-io>2.19.0</dependency.commons-io>
+        <dependency.commons-io>2.20.0</dependency.commons-io>
         <dependency.commons-lang>3.18.0</dependency.commons-lang>
         <dependency.kafka>3.9.1</dependency.kafka>
         <dependency.log4j2>2.25.1</dependency.log4j2>
@@ -100,10 +100,10 @@
 
         <!-- Test dependencies -->
         <dependency.awaitility>4.3.0</dependency.awaitility>
-        <dependency.junit5>5.13.3</dependency.junit5>
+        <dependency.junit5>5.13.4</dependency.junit5>
         <dependency.junit5-platform>1.10.1</dependency.junit5-platform>
         <dependency.logback>1.5.18</dependency.logback>
-        <dependency.log4j2>2.25.0</dependency.log4j2>
+        <dependency.log4j2>2.25.1</dependency.log4j2>
         <dependency.mockito>5.18.0</dependency.mockito>
         <dependency.testcontainers>1.21.3</dependency.testcontainers>
         <dependency.testng>7.11.0</dependency.testng>


### PR DESCRIPTION
This picks up the Smart Caches Core fix telicent-oss/smart-caches-core#162 that was first spotted while testing the Fuseki Kafka module code.  Related to this now adds a monitoring thread into Fuseki Kafka that tracks the Kafka polling threads logging if any of them exit unexpectedly.

It also fixes another subtle bug spotted while testing telicent-oss/smart-cache-graph#247 that the Kafka offsets were off by 1 when upgrading from the legacy state file format that meant an event was unnecessarily reprocessed.

Plus generally upgrades dependencies to latest available