### PR TITLE
Add Low Volume and High Lag batching modes (CORE-905)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Kafka Connector for Apache Jena Fuseki
 
+## 2.1.0
+
+- `FusekiProjector` batching improvements:
+    - The automatic batching logic in `FusekiProjector` has been improved to handle two key edge cases observed in
+      production usage:
+        - When experiencing high lag then batching by number of events is disabled and batching is instead done by
+          amount of data received.  This works particularly well when far behind a topic containing lots of small
+          messages as it reduces the number of transactions which speeds up processing.
+        - When connecting to a low volume topic, or the input topic is populated by a slow producer, such that we are
+          frequently up to date (lag=0) and committing small batches then committing at zero lag is disabled and instead
+          done only when batch size/max transaction duration is reached.  This reduces the number of transactions for
+          such topics again improving performance by limiting transaction overheads.
+        - Both of these modes automatically switch back to normal batching behaviour as and when the triggering
+          conditions are no longer present.
+    - Added support for custom Fuseki Kafka specific properties to be supplied to control all of the above behaviours
+
 ## 2.0.2
 
 - Fixed a bug where upgrading legacy state files caused Kafka offsets to be off by 1 resulting in re-processing an event

--- a/jena-fuseki-kafka-module/src/main/java/org/apache/jena/fuseki/kafka/FKS.java
+++ b/jena-fuseki-kafka-module/src/main/java/org/apache/jena/fuseki/kafka/FKS.java
@@ -190,6 +190,7 @@ public class FKS {
     private static final List<Future<?>> ACTIVE_DRIVERS = new ArrayList<>();
     private static PollThreadMonitor MONITOR;
     private static ExecutorService EXECUTOR = threadExecutor();
+
     private static ExecutorService threadExecutor() {
         ExecutorService executor = Executors.newCachedThreadPool();
 
@@ -207,8 +208,10 @@ public class FKS {
     static void resetPollThreads() {
         // Explicitly cancel the projector drivers
         MONITOR.cancel();
-        for (ProjectorDriver<Bytes, RdfPayload, Event<Bytes, RdfPayload>> driver : DRIVERS.values().stream().flatMap(
-                Collection::stream).toList()) {
+        for (ProjectorDriver<Bytes, RdfPayload, Event<Bytes, RdfPayload>> driver : DRIVERS.values()
+                                                                                          .stream()
+                                                                                          .flatMap(Collection::stream)
+                                                                                          .toList()) {
             driver.cancel();
         }
         DRIVERS.clear();
@@ -253,7 +256,8 @@ public class FKS {
                                                          .source(source)
                                                          .dataset(destination)
                                                          .connector(connector)
-                                                         .batchSize(connector.getMaxPollRecords())
+                                                         .batchSize(connector.getBatchSize())
+                                                         .maxTransactionDuration(connector.getMaxTransactionDuration())
                                                          .dlq(dlq)
                                                          .build())
                                .destination(sinkBuilder.apply(destination))
@@ -293,9 +297,7 @@ public class FKS {
      * @return Default sink builder function
      */
     public static Function<DatasetGraph, Sink<Event<Bytes, RdfPayload>>> defaultSinkBuilder() {
-        return dsg -> FusekiSink.builder()
-                                .dataset(dsg)
-                                .build();
+        return dsg -> FusekiSink.builder().dataset(dsg).build();
     }
 
     /**

--- a/jena-kafka-connector/pom.xml
+++ b/jena-kafka-connector/pom.xml
@@ -68,6 +68,17 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>${dependency.commons-io}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-math3</artifactId>
+            <version>${dependency.commons-math}</version>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.kafka</groupId>

--- a/jena-kafka-connector/src/main/java/org/apache/jena/kafka/KConnectorDesc.java
+++ b/jena-kafka-connector/src/main/java/org/apache/jena/kafka/KConnectorDesc.java
@@ -16,9 +16,12 @@
 
 package org.apache.jena.kafka;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -33,12 +36,21 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
  * href="https://github.com/telicent-oss/smart-caches-core/blob/main/docs/event-sources/kafka.md">Telicent Smart Cache
  * Core Libraries</a>.
  * </p>
+ * <p>
+ * Transaction management and handling is done by {@link org.apache.jena.kafka.common.FusekiProjector}, a number of
+ * methods on the connector provide advanced configuration tuning for this.  The values returned by these methods are
+ * driven from custom Fuseki Kafka configuration properties supplied as part of the Kafka configuration properties
+ * available via {@link #getKafkaConsumerProps()}.  See individual methods for what configuration properties to use, and
+ * the defaults used if not explicitly configured.
+ * </p>
  */
 @Getter
 @ToString
 @EqualsAndHashCode
 public class KConnectorDesc {
 
+    private static final Predicate<Integer> IS_POSITIVE_INTEGER = x -> x != null && x > 0;
+    private static final Predicate<Long> IS_POSITIVE_LONG = x -> x != null && x > 0;
     // Source
     private final List<String> topics;
     private final String dlqTopic;
@@ -95,18 +107,144 @@ public class KConnectorDesc {
         return this.kafkaConsumerProps.getProperty(ConsumerConfig.GROUP_ID_CONFIG);
     }
 
+    private <T> T fromKafkaProperties(String key, Function<String, T> parser, Predicate<T> validator, T defaultValue) {
+        String rawValue = this.kafkaConsumerProps.getProperty(key);
+        if (StringUtils.isBlank(rawValue)) {
+            return defaultValue;
+        } else {
+            try {
+                T value = parser.apply(rawValue);
+                return validator.test(value) ? value : defaultValue;
+            } catch (Throwable e) {
+                return defaultValue;
+            }
+        }
+    }
+
+    private <T> T fromKafkaProperties(String[] keys, Function<String, T> parser, Predicate<T> validator,
+                                      T defaultValue) {
+        for (String key : keys) {
+            T value = fromKafkaProperties(key, parser, validator, null);
+            if (value != null) {
+                return value;
+            }
+        }
+        return defaultValue;
+    }
+
     /**
      * Gets the maximum poll records as configured for the connector
      *
      * @return Maximum poll records
      */
     public int getMaxPollRecords() {
-        String rawValue = this.kafkaConsumerProps.getProperty(ConsumerConfig.MAX_POLL_RECORDS_CONFIG);
-        if (StringUtils.isBlank(rawValue)) {
-            return SysJenaKafka.KAFKA_FETCH_POLL_SIZE;
-        } else {
-            return Integer.parseInt(rawValue);
-        }
+        return fromKafkaProperties(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, Integer::parseInt, IS_POSITIVE_INTEGER,
+                                   SysJenaKafka.KAFKA_FETCH_POLL_SIZE);
+    }
+
+    /**
+     * Gets the batch size to use, in number of events, this is taken from the following in precedence order:
+     * <ol>
+     *     <li>The custom Fuseki Kafka configuration property {@value SysJenaKafka#FUSEKI_KAFKA_BATCH_SIZE}</li>
+     *     <li>The Kafka configuration property {@value ConsumerConfig#MAX_POLL_RECORDS_CONFIG}</li>
+     *     <li>The Fuseki Kafka default {@value SysJenaKafka#KAFKA_FETCH_POLL_SIZE}</li>
+     * </ol>
+     *
+     * @return Batch size, in number of events, to use
+     */
+    public int getBatchSize() {
+        return fromKafkaProperties(
+                new String[] { SysJenaKafka.FUSEKI_KAFKA_BATCH_SIZE, ConsumerConfig.MAX_POLL_RECORDS_CONFIG },
+                Integer::parseInt, IS_POSITIVE_INTEGER, SysJenaKafka.KAFKA_FETCH_POLL_SIZE);
+    }
+
+    /**
+     * Gets the batch size to use, in number of bytes, this is taken from the following in precedence order:
+     * <ol>
+     *     <li>The custom Fuseki Kafka configuration property {@value SysJenaKafka#FUSEKI_KAFKA_BATCH_SIZE_BYTES}</li>
+     *     <li>The Kafka configuration property {@value ConsumerConfig#FETCH_MAX_BYTES_CONFIG}</li>
+     *     <li>The Kafka configuration property {@value ConsumerConfig#MAX_PARTITION_FETCH_BYTES_CONFIG}</li>
+     *     <li>The Fuseki Kafka default {@value SysJenaKafka#DEFAULT_HIGH_LAG_BATCH_BYTE_THRESHOLD}</li>
+     * </ol>
+     * <p>
+     * Note that this configuration is only used when the {@link #getHighLagThreshold()} is exceeded.
+     * </p>
+     *
+     * @return Batch size, in number of bytes, to use
+     */
+    public long getBatchSizeBytes() {
+        return fromKafkaProperties(new String[] {
+                SysJenaKafka.FUSEKI_KAFKA_BATCH_SIZE_BYTES,
+                ConsumerConfig.FETCH_MAX_BYTES_CONFIG,
+                ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG
+        }, Long::parseLong, IS_POSITIVE_LONG, SysJenaKafka.DEFAULT_HIGH_LAG_BATCH_BYTE_THRESHOLD);
+    }
+
+    /**
+     * Gets the number of batch sizes to track in order to average batch sizes over this and determine whether we're
+     * connected to low volume topics.
+     * <p>
+     * Configured by the custom Fuseki Kafka property {@value SysJenaKafka#FUSEKI_KAFKA_BATCH_SIZE_TRACKING}, using a
+     * default of {@value SysJenaKafka#DEFAULT_BATCH_SIZE_TRACKING_WINDOW}.  Once at least this many batches have been
+     * processed if the average batch size falls below the configured {@link #getLowVolumeBatchSizeThreshold()} then the
+     * {@link org.apache.jena.kafka.common.FusekiProjector} switches over to low volume batching mode.  In this mode it
+     * does not automatically commit as soon as it reaches lag of 0 instead waiting until either the batch size, or the
+     * {@link #getMaxTransactionDuration()} is exceeded.
+     * </p>
+     *
+     * @return Number of batch sizes to track
+     */
+    public int getBatchSizeTrackingWindow() {
+        return fromKafkaProperties(SysJenaKafka.FUSEKI_KAFKA_BATCH_SIZE_TRACKING, Integer::parseInt,
+                                   IS_POSITIVE_INTEGER,
+                                   SysJenaKafka.DEFAULT_BATCH_SIZE_TRACKING_WINDOW);
+    }
+
+    /**
+     * Gets the low volume batch size threshold
+     * <p>
+     * If the average batch size over the last {@link #getBatchSizeTrackingWindow()} batches is less than, or equal to,
+     * this threshold then the {@link org.apache.jena.kafka.common.FusekiProjector} switches over to low volume batching
+     * mode.  See {@link #getBatchSizeTrackingWindow()} for more details on this.
+     * </p>
+     *
+     * @return Low volume batch size threshold
+     */
+    public int getLowVolumeBatchSizeThreshold() {
+        return fromKafkaProperties(SysJenaKafka.FUSEKI_KAFKA_LOW_VOLUME_THRESHOLD, Integer::parseInt,
+                                   IS_POSITIVE_INTEGER,
+                                   SysJenaKafka.DEFAULT_AVERAGE_BATCH_SIZE_LOW_VOLUME_THRESHOLD);
+    }
+
+    /**
+     * Gets the high lag threshold, in number of events.
+     * <p>
+     * If the lag exceeds this then the {@link org.apache.jena.kafka.common.FusekiProjector} switches to high lag
+     * batching mode.  In this mode it no longer honours the {@link #getBatchSize()} instead only committing once
+     * {@link #getBatchSizeBytes()} has been reached.
+     * </p>
+     *
+     * @return High lag threshold
+     */
+    public long getHighLagThreshold() {
+        return fromKafkaProperties(SysJenaKafka.FUSEKI_KAFKA_HIGH_LAG_THRESHOLD, Long::parseLong,
+                                   IS_POSITIVE_LONG,
+                                   SysJenaKafka.DEFAULT_HIGH_LAG_THRESHOLD);
+    }
+
+    /**
+     * Gets the maximum transaction duration
+     * <p>
+     * This is expressed as an ISO 8601 Duration in the Kafka configuration e.g. {@code PT5M} is 5 minutes, defaults to
+     * {@link SysJenaKafka#DEFAULT_MAX_TRANSACTION_DURATION}.
+     * </p>
+     *
+     * @return Max transaction duration
+     */
+    public Duration getMaxTransactionDuration() {
+        return fromKafkaProperties(SysJenaKafka.FUSEKI_KAFKA_MAX_TRANSACTION_DURATION, Duration::parse,
+                                   SysJenaKafka::isValidDuration,
+                                   SysJenaKafka.DEFAULT_MAX_TRANSACTION_DURATION);
     }
 
 }

--- a/jena-kafka-connector/src/main/java/org/apache/jena/kafka/SysJenaKafka.java
+++ b/jena-kafka-connector/src/main/java/org/apache/jena/kafka/SysJenaKafka.java
@@ -19,6 +19,7 @@ package org.apache.jena.kafka;
 import java.time.Duration;
 import java.util.Properties;
 
+import io.telicent.smart.cache.sources.EventSource;
 import org.apache.jena.atlas.lib.Version;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 
@@ -35,6 +36,69 @@ public class SysJenaKafka {
      * Software version taken from the jar file.
      */
     public static final String VERSION = Version.versionForClass(FusekiKafka.class).orElse("<development>");
+    /**
+     * Default maximum transaction duration for the {@link org.apache.jena.kafka.common.FusekiProjector}, if a
+     * transaction exceeds this time then it will be committed
+     */
+    public static final Duration DEFAULT_MAX_TRANSACTION_DURATION = Duration.ofMinutes(5);
+    /**
+     * Default number of recent batch sizes which will be tracked by the
+     * {@link org.apache.jena.kafka.common.FusekiProjector} to detect scenarios where we're receiving low volumes of
+     * data and thus may be generating too small batches
+     */
+    public static final int DEFAULT_BATCH_SIZE_TRACKING_WINDOW = 25;
+    /**
+     * The threshold, in number of events, at/below which topics are considered low volume and the
+     * {@link org.apache.jena.kafka.common.FusekiProjector} will switch to low volume batching mode.
+     * <p>
+     * When in low volume batching mode we do not immediately commit on reaching zero lag, rather we wait until we are
+     * definitely stalled (no new events from a {@link EventSource#poll(Duration)}) or until our maximum transaction
+     * duration has been exceeded.
+     * </p>
+     */
+    public static final int DEFAULT_AVERAGE_BATCH_SIZE_LOW_VOLUME_THRESHOLD = 10;
+    /**
+     * The threshold, in number of events, beyond which topics are considered high lag and the
+     * {@link org.apache.jena.kafka.common.FusekiProjector} will switch to high lag batching mode.  See
+     * {@link #DEFAULT_HIGH_LAG_BATCH_BYTE_THRESHOLD} for more details.
+     */
+    public static final long DEFAULT_HIGH_LAG_THRESHOLD = 10_000;
+    /**
+     * High lag batch byte threshold (50MB)
+     * <p>
+     * When the {@link org.apache.jena.kafka.common.FusekiProjector} detects that it is experiencing high lag in
+     * catching up with a Kafka topic it stops respecting the batch size (number of events) threshold and instead
+     * switches to maximising batch size by going by batch size in bytes instead.  As in practise most events are quite
+     * small (few kilobytes to few hundred kilobytes) just batching by number of events may lead to smaller than desired
+     * batches which introduces more frequent transaction overheads.  Therefore, changing batching mode to be data size
+     * based leads to more predictable and stable batch sizes when catching up on high lag.
+     * </p>
+     */
+    public static final long DEFAULT_HIGH_LAG_BATCH_BYTE_THRESHOLD = 50 * 1024 * 1024;
+    /**
+     * Custom Fuseki Kafka configuration property used for {@link KConnectorDesc#getBatchSize()}
+     */
+    public static final String FUSEKI_KAFKA_BATCH_SIZE = "fuseki.kafka.batch.size";
+    /**
+     * Custom Fuseki Kafka configuration property used for {@link KConnectorDesc#getBatchSizeBytes()}
+     */
+    public static final String FUSEKI_KAFKA_BATCH_SIZE_BYTES = "fuseki.kafka.batch.size.bytes";
+    /**
+     * Custom Fuseki Kafka configuration property used for {@link KConnectorDesc#getMaxTransactionDuration()}
+     */
+    public static final String FUSEKI_KAFKA_MAX_TRANSACTION_DURATION = "fuseki.kafka.max.transaction.duration";
+    /**
+     * Custom Fuseki Kafka configuration property used for {@link KConnectorDesc#getBatchSizeTrackingWindow()}
+     */
+    public static final String FUSEKI_KAFKA_BATCH_SIZE_TRACKING = "fuseki.kafka.batch.size.tracking";
+    /**
+     * Custom Fuseki Kafka configuration property used for {@link KConnectorDesc#getLowVolumeBatchSizeThreshold()}
+     */
+    public static final String FUSEKI_KAFKA_LOW_VOLUME_THRESHOLD = "fuseki.kafka.low.volume.threshold";
+    /**
+     * Custom Fuseki Kafka configuration property used for {@link KConnectorDesc#getHighLagThreshold()}
+     */
+    public static final String FUSEKI_KAFKA_HIGH_LAG_THRESHOLD = "fuseki.kafka.high.lag.threshold";
 
     /**
      * Size in bytes per {@link org.apache.kafka.clients.consumer.KafkaConsumer#poll(Duration)} in a system.
@@ -56,6 +120,10 @@ public class SysJenaKafka {
      * {@value ConsumerConfig#DEFAULT_MAX_POLL_RECORDS}.
      */
     public static int KAFKA_FETCH_POLL_SIZE = 5000;
+    /**
+     * Default batch size, in number of events, if not otherwise configured
+     */
+    public static int DEFAULT_BATCH_SIZE = 1000;
 
     /**
      * Kafka consumer properties.
@@ -73,5 +141,16 @@ public class SysJenaKafka {
         // Set the bootstrap server(s)
         props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, server);
         return props;
+    }
+
+    /**
+     * Checks whether the given duration is valid for configuration purposes i.e. it is non-null, non-negative and
+     * non-zero
+     *
+     * @param duration Duration to test
+     * @return True if valid, false otherwise
+     */
+    public static boolean isValidDuration(Duration duration) {
+        return duration != null && !duration.isNegative() && !duration.isZero();
     }
 }

--- a/jena-kafka-connector/src/test/java/org/apache/jena/kafka/common/AbstractFusekiProjectorTests.java
+++ b/jena-kafka-connector/src/test/java/org/apache/jena/kafka/common/AbstractFusekiProjectorTests.java
@@ -1,0 +1,162 @@
+package org.apache.jena.kafka.common;
+
+import io.telicent.smart.cache.payloads.RdfPayload;
+import io.telicent.smart.cache.projectors.Sink;
+import io.telicent.smart.cache.projectors.sinks.NullSink;
+import io.telicent.smart.cache.sources.Event;
+import io.telicent.smart.cache.sources.EventSource;
+import io.telicent.smart.cache.sources.memory.SimpleEvent;
+import org.apache.jena.kafka.KConnectorDesc;
+import org.apache.jena.query.ReadWrite;
+import org.apache.jena.query.TxnType;
+import org.apache.jena.sparql.JenaTransactionException;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sys.JenaSystem;
+import org.apache.kafka.common.utils.Bytes;
+import org.junit.jupiter.api.Assertions;
+import org.mockito.Mockito;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+public class AbstractFusekiProjectorTests {
+    static {
+        JenaSystem.init();
+    }
+
+    /**
+     * Creates a mock {@link DatasetGraph} that exhibits the normal Jena transaction behaviour and can be used to verify
+     * interactions created by the projector and sink
+     *
+     * @return Mock dataset graph
+     */
+    public static DatasetGraph mockDatasetGraph() {
+        DatasetGraph dsg = Mockito.mock(DatasetGraph.class);
+        AtomicBoolean inTransaction = new AtomicBoolean(false);
+        when(dsg.isInTransaction()).thenAnswer(x -> inTransaction.get());
+        doAnswer(x -> {
+            if (inTransaction.get()) {
+                throw new JenaTransactionException("Already in transaction");
+            }
+            inTransaction.set(true);
+            return null;
+        }).when(dsg).begin(any(TxnType.class));
+        doAnswer(x -> {
+            if (inTransaction.get()) {
+                throw new JenaTransactionException("Already in transaction");
+            }
+            inTransaction.set(true);
+            return null;
+        }).when(dsg).begin(any(ReadWrite.class));
+        doAnswer(x -> {
+            inTransaction.set(false);
+            return null;
+        }).when(dsg).commit();
+        doAnswer(x -> {
+            inTransaction.set(false);
+            return null;
+        }).when(dsg).abort();
+        return dsg;
+    }
+
+    /**
+     * Verifies projection using the real {@link FusekiSink}, this is necessary for verifying handling of RDF patch
+     * events
+     *
+     * @param source                            Event source
+     * @param projector                         Projector
+     * @param dsg                               Dataset graph
+     * @param expectedExternalBeginTransactions Expected number of external begin transaction calls
+     * @param expectedPatchBeginTransactions    Expected number of RDF patch begin transaction calls
+     * @param expectedCommits                   Expected number of commits
+     */
+    protected static void verifyFusekiSinkProjection(EventSource<Bytes, RdfPayload> source, FusekiProjector projector,
+                                                     DatasetGraph dsg, int expectedExternalBeginTransactions,
+                                                     int expectedPatchBeginTransactions, int expectedCommits) {
+        AbstractFusekiProjectorTests.projectToFusekiSink(source, projector, dsg);
+
+        // Then
+        verify(dsg, times(expectedExternalBeginTransactions)).begin((TxnType) any());
+        verify(dsg, times(expectedPatchBeginTransactions)).begin((ReadWrite) any());
+        verify(dsg, times(expectedCommits)).commit();
+    }
+
+    protected static void projectToFusekiSink(EventSource<Bytes, RdfPayload> source, FusekiProjector projector,
+                                              DatasetGraph dsg) {
+        // When
+        try (FusekiSink<DatasetGraph> sink = FusekiSink.builder().dataset(dsg).build();) {
+            while (!source.isExhausted()) {
+                projector.project(source.poll(Duration.ZERO), sink);
+            }
+        }
+    }
+
+    protected static SimpleEvent<Bytes, RdfPayload> createTestDatasetEvent() {
+        return new SimpleEvent<>(Collections.emptyList(), null,
+                                 RdfPayload.of(TestFusekiSink.createSimpleDatasetPayload()));
+    }
+
+    public static FusekiProjector buildProjector(KConnectorDesc connector, EventSource<Bytes, RdfPayload> source,
+                                                 DatasetGraph dsg, int batchSize) {
+        return AbstractFusekiProjectorTests.buildProjector(connector, source, dsg, batchSize, null, null);
+    }
+
+    public static FusekiProjector buildProjector(KConnectorDesc connector, EventSource<Bytes, RdfPayload> source,
+                                                 DatasetGraph dsg, int batchSize, Sink<Event<Bytes, RdfPayload>> dlq) {
+        return AbstractFusekiProjectorTests.buildProjector(connector, source, dsg, batchSize, null, dlq);
+    }
+
+    public static FusekiProjector buildProjector(KConnectorDesc connector, EventSource<Bytes, RdfPayload> source,
+                                                 DatasetGraph dsg, int batchSize, Duration maxTransactionDuration,
+                                                 Sink<Event<Bytes, RdfPayload>> dlq) {
+        return FusekiProjector.builder()
+                              .connector(connector)
+                              .source(source)
+                              .dataset(dsg)
+                              .batchSize(batchSize)
+                              .maxTransactionDuration(maxTransactionDuration)
+                              .dlq(dlq)
+                              .build();
+    }
+
+    protected static KConnectorDesc createTestConnector() {
+        return new KConnectorDesc(List.of("test"), "localhost:9092", "/ds", null, true, false, null, new Properties());
+    }
+
+    public static void verifyProjection(EventSource<Bytes, RdfPayload> source, FusekiProjector projector,
+                                        DatasetGraph dsg, long expectedEvents, int expectedBeginTransactions,
+                                        int expectedCommitTransactions) {
+        try (NullSink<Event<Bytes, RdfPayload>> sink = NullSink.of()) {
+            while (!source.isExhausted()) {
+                projector.project(source.poll(Duration.ZERO), sink);
+            }
+
+            // Then
+            Assertions.assertEquals(expectedEvents, sink.count());
+            verify(dsg, times(expectedBeginTransactions)).begin((TxnType) any());
+            verify(dsg, times(expectedCommitTransactions)).commit();
+        }
+    }
+
+    protected static void verifyNoTransactions(DatasetGraph dsg) {
+        verify(dsg, never()).begin((TxnType) any());
+        verify(dsg, never()).begin((ReadWrite) any());
+        verify(dsg, never()).commit();
+    }
+
+    protected static void sendEvents(FusekiProjector projector, EventSource<Bytes, RdfPayload> source,
+                                     NullSink<Event<Bytes, RdfPayload>> sink, int count) {
+        for (int i = 0; i < count; i++) {
+            if (source.isExhausted()) return;
+            Event<Bytes, RdfPayload> event = source.poll(Duration.ofSeconds(3));
+            if (event == null) return;
+            projector.project(event, sink);
+        }
+    }
+}

--- a/jena-kafka-connector/src/test/java/org/apache/jena/kafka/common/RemainingVolumeSource.java
+++ b/jena-kafka-connector/src/test/java/org/apache/jena/kafka/common/RemainingVolumeSource.java
@@ -1,0 +1,86 @@
+package org.apache.jena.kafka.common;
+
+import io.telicent.smart.cache.payloads.RdfPayload;
+import io.telicent.smart.cache.sources.Event;
+import io.telicent.smart.cache.sources.EventSource;
+import org.apache.kafka.common.utils.Bytes;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.function.Supplier;
+
+/**
+ * A test event source where the remaining value is configurable and can ramp up over time
+ */
+public class RemainingVolumeSource implements EventSource<Bytes, RdfPayload> {
+
+    private final double maxRemainingMultiplier;
+    private double maxRemaining;
+    private long currentRemaining;
+    private final Supplier<Event<Bytes, RdfPayload>> eventSupplier;
+
+    /**
+     * Creates a new test event source
+     *
+     * @param initialMaxRemaining    Initial number of remaining events to report
+     * @param maxRemainingMultiplier The multiplier that increases/decreases the remaining events over time
+     * @param supplier               Supplier for generating the actual events
+     */
+    public RemainingVolumeSource(long initialMaxRemaining, double maxRemainingMultiplier,
+                                 Supplier<Event<Bytes, RdfPayload>> supplier) {
+        this.maxRemainingMultiplier = maxRemainingMultiplier;
+        this.maxRemaining = initialMaxRemaining;
+        this.currentRemaining = initialMaxRemaining;
+        this.eventSupplier = supplier;
+    }
+
+    @Override
+    public boolean availableImmediately() {
+        return this.currentRemaining > 0;
+    }
+
+    @Override
+    public boolean isExhausted() {
+        return this.maxRemaining <= 0.0;
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    @Override
+    public boolean isClosed() {
+        return false;
+    }
+
+    @Override
+    public Event<Bytes, RdfPayload> poll(Duration duration) {
+        if (this.isExhausted()) {
+            return null;
+        }
+
+        if (this.currentRemaining == 0) {
+            // Reset our remaining, scaling up the max remaining if a multiplier > 1 has been configured
+            double prevMaxRemaining = this.maxRemaining;
+            this.maxRemaining = prevMaxRemaining * this.maxRemainingMultiplier;
+            if (this.maxRemaining < 1) {
+                this.maxRemaining = 0;
+            }
+            this.currentRemaining = Math.max(0, Math.round(this.maxRemaining));
+            if (this.currentRemaining == 0) return null;
+        }
+        this.currentRemaining--;
+        return eventSupplier.get();
+    }
+
+    @Override
+    public Long remaining() {
+        return this.currentRemaining;
+    }
+
+    @Override
+    public void processed(Collection<Event> collection) {
+
+    }
+}

--- a/jena-kafka-connector/src/test/java/org/apache/jena/kafka/common/TestFusekiProjector.java
+++ b/jena-kafka-connector/src/test/java/org/apache/jena/kafka/common/TestFusekiProjector.java
@@ -11,13 +11,9 @@ import io.telicent.smart.cache.sources.memory.InMemoryEventSource;
 import io.telicent.smart.cache.sources.memory.SimpleEvent;
 import org.apache.jena.kafka.JenaKafkaException;
 import org.apache.jena.kafka.KConnectorDesc;
-import org.apache.jena.query.ReadWrite;
-import org.apache.jena.query.TxnType;
 import org.apache.jena.rdfpatch.changes.RDFChangesCollector;
-import org.apache.jena.sparql.JenaTransactionException;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.DatasetGraphFactory;
-import org.apache.jena.sys.JenaSystem;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.utils.Bytes;
 import org.junit.jupiter.api.Assertions;
@@ -25,137 +21,15 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.Mockito;
 
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Properties;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
-public class TestFusekiProjector {
-    static {
-        JenaSystem.init();
-    }
-
-    /**
-     * Creates a mock {@link DatasetGraph} that exhibits the normal Jena transaction behaviour and can be used to verify
-     * interactions created by the projector and sink
-     *
-     * @return Mock dataset graph
-     */
-    public static DatasetGraph mockDatasetGraph() {
-        DatasetGraph dsg = Mockito.mock(DatasetGraph.class);
-        AtomicBoolean inTransaction = new AtomicBoolean(false);
-        when(dsg.isInTransaction()).thenAnswer(x -> inTransaction.get());
-        doAnswer(x -> {
-            if (inTransaction.get()) {
-                throw new JenaTransactionException("Already in transaction");
-            }
-            inTransaction.set(true);
-            return null;
-        }).when(dsg).begin(any(TxnType.class));
-        doAnswer(x -> {
-            if (inTransaction.get()) {
-                throw new JenaTransactionException("Already in transaction");
-            }
-            inTransaction.set(true);
-            return null;
-        }).when(dsg).begin(any(ReadWrite.class));
-        doAnswer(x -> {
-            inTransaction.set(false);
-            return null;
-        }).when(dsg).commit();
-        doAnswer(x -> {
-            inTransaction.set(false);
-            return null;
-        }).when(dsg).abort();
-        return dsg;
-    }
-
-    /**
-     * Verifies projection using the real {@link FusekiSink}, this is necessary for verifying handling of RDF patch
-     * events
-     *
-     * @param source                            Event source
-     * @param projector                         Projector
-     * @param dsg                               Dataset graph
-     * @param expectedExternalBeginTransactions Expected number of external begin transaction calls
-     * @param expectedPatchBeginTransactions    Expected number of RDF patch begin transaction calls
-     * @param expectedCommits                   Expected number of commits
-     */
-    private static void verifyFusekiSinkProjection(EventSource<Bytes, RdfPayload> source, FusekiProjector projector,
-                                                   DatasetGraph dsg, int expectedExternalBeginTransactions,
-                                                   int expectedPatchBeginTransactions, int expectedCommits) {
-        projectToFusekiSink(source, projector, dsg);
-
-        // Then
-        verify(dsg, times(expectedExternalBeginTransactions)).begin((TxnType) any());
-        verify(dsg, times(expectedPatchBeginTransactions)).begin((ReadWrite) any());
-        verify(dsg, times(expectedCommits)).commit();
-    }
-
-    private static void projectToFusekiSink(EventSource<Bytes, RdfPayload> source, FusekiProjector projector,
-                                            DatasetGraph dsg) {
-        // When
-        try (FusekiSink sink = FusekiSink.builder().dataset(dsg).build();) {
-            while (!source.isExhausted()) {
-                projector.project(source.poll(Duration.ZERO), sink);
-            }
-        }
-    }
-
-    private static SimpleEvent<Bytes, RdfPayload> createTestDatasetEvent() {
-        return new SimpleEvent<>(Collections.emptyList(), null,
-                                 RdfPayload.of(TestFusekiSink.createSimpleDatasetPayload()));
-    }
-
-    public static FusekiProjector buildProjector(KConnectorDesc connector, EventSource<Bytes, RdfPayload> source,
-                                                 DatasetGraph dsg, int batchSize) {
-        return buildProjector(connector, source, dsg, batchSize, null, null);
-    }
-
-    public static FusekiProjector buildProjector(KConnectorDesc connector, EventSource<Bytes, RdfPayload> source,
-                                                 DatasetGraph dsg, int batchSize, Sink<Event<Bytes, RdfPayload>> dlq) {
-        return buildProjector(connector, source, dsg, batchSize, null, dlq);
-    }
-
-    public static FusekiProjector buildProjector(KConnectorDesc connector, EventSource<Bytes, RdfPayload> source,
-                                                 DatasetGraph dsg, int batchSize, Duration maxTransactionDuration,
-                                                 Sink<Event<Bytes, RdfPayload>> dlq) {
-        return FusekiProjector.builder()
-                              .connector(connector)
-                              .source(source)
-                              .dataset(dsg)
-                              .batchSize(batchSize)
-                              .maxTransactionDuration(maxTransactionDuration)
-                              .dlq(dlq)
-                              .build();
-    }
-
-    private static KConnectorDesc createTestConnector() {
-        return new KConnectorDesc(List.of("test"), "localhost:9092", "/ds", null, true, false, null, new Properties());
-    }
-
-    public static void verifyProjection(EventSource<Bytes, RdfPayload> source, FusekiProjector projector,
-                                        DatasetGraph dsg, long expectedEvents, int expectedBeginTransactions,
-                                        int expectedCommitTransactions) {
-        try (NullSink<Event<Bytes, RdfPayload>> sink = NullSink.of()) {
-            while (!source.isExhausted()) {
-                projector.project(source.poll(Duration.ZERO), sink);
-            }
-
-            // Then
-            Assertions.assertEquals(expectedEvents, sink.count());
-            verify(dsg, times(expectedBeginTransactions)).begin((TxnType) any());
-            verify(dsg, times(expectedCommitTransactions)).commit();
-        }
-    }
+public class TestFusekiProjector extends AbstractFusekiProjectorTests {
 
     @Test
     public void givenNoParameters_whenBuildingProjector_thenNPE() {
@@ -320,30 +194,6 @@ public class TestFusekiProjector {
         verifyProjection(source, projector, dsg, 3, 1, 0);
     }
 
-    private List<Event<Bytes, RdfPayload>> createKafkaTestEvents(int size) {
-        List<Event<Bytes, RdfPayload>> events = new ArrayList<>();
-        for (int i = 0; i < size; i++) {
-            ConsumerRecord<Bytes, RdfPayload> record = new ConsumerRecord<>("test", 0, i, Bytes.wrap(new byte[0]),
-                                                                            RdfPayload.of(
-                                                                                    TestFusekiSink.createSimpleDatasetPayload()));
-            events.add(new KafkaEvent<>(record, null));
-        }
-        return events;
-    }
-
-    @Test
-    public void givenBatchingProjector_whenProjectingKafkaEventsEquallingBatchSize_thenProjectedWithSingleTransaction() {
-        // Given
-        KConnectorDesc connector = createTestConnector();
-        List<Event<Bytes, RdfPayload>> kafkaEvents = createKafkaTestEvents(3);
-        EventSource<Bytes, RdfPayload> source = new InMemoryEventSource<>(kafkaEvents);
-        DatasetGraph dsg = mockDatasetGraph();
-        FusekiProjector projector = buildProjector(connector, source, dsg, 3);
-
-        // When and Then
-        verifyProjection(source, projector, dsg, 3, 1, 1);
-    }
-
     @Test
     public void givenProjector_whenProjectingPatchThatCommitsTheTransaction_thenNoAdditionalCommits() {
         // Given
@@ -473,12 +323,6 @@ public class TestFusekiProjector {
         verifyNoTransactions(dsg);
     }
 
-    private static void verifyNoTransactions(DatasetGraph dsg) {
-        verify(dsg, never()).begin((TxnType) any());
-        verify(dsg, never()).begin((ReadWrite) any());
-        verify(dsg, never()).commit();
-    }
-
     @Test
     public void givenProjectorWithDlq_whenProjectingMalformedRdfPayload_thenNoTransaction() {
         // Given
@@ -528,87 +372,5 @@ public class TestFusekiProjector {
 
         // Then
         verifyNoTransactions(dsg);
-    }
-
-    @Test
-    public void givenProjectorInTransaction_whenStalling_thenCommits() {
-        // Given
-        DatasetGraph dsg = mockDatasetGraph();
-        KConnectorDesc connector = createTestConnector();
-        NullSink<Event<Bytes, RdfPayload>> sink = NullSink.of();
-        EventSource<Bytes, RdfPayload> source = new InMemoryEventSource<>(createKafkaTestEvents(10));
-        FusekiProjector projector = buildProjector(connector, source, dsg, 10, sink);
-
-        // When
-        projector.project(createTestDatasetEvent(), sink);
-        projector.stalled(sink);
-
-        // Then
-        Assertions.assertEquals(1L, sink.count());
-        verify(dsg, times(1)).begin((TxnType) any());
-        verify(dsg, times(1)).commit();
-    }
-
-    @Test
-    public void givenNonBatchingProjector_whenStalling_thenNoAdditionalCommits() {
-        // Given
-        DatasetGraph dsg = mockDatasetGraph();
-        KConnectorDesc connector = createTestConnector();
-        NullSink<Event<Bytes, RdfPayload>> sink = NullSink.of();
-        EventSource<Bytes, RdfPayload> source = new InMemoryEventSource<>(createKafkaTestEvents(10));
-        FusekiProjector projector = buildProjector(connector, source, dsg, 1, sink);
-
-        // When
-        projector.project(createTestDatasetEvent(), sink);
-        projector.stalled(sink);
-
-        // Then
-        Assertions.assertEquals(1L, sink.count());
-        verify(dsg, times(1)).begin((TxnType) any());
-        verify(dsg, times(1)).commit();
-    }
-
-    @Test
-    public void givenProjectorWithMaxTransactionDuration_whenReceivingEventsSlowly_thenCommitsTriggeredByTimeThreshold() throws
-            InterruptedException {
-        // Given
-        DatasetGraph dsg = mockDatasetGraph();
-        KConnectorDesc connector = createTestConnector();
-        NullSink<Event<Bytes, RdfPayload>> sink = NullSink.of();
-        EventSource<Bytes, RdfPayload> source = new InMemoryEventSource<>(createKafkaTestEvents(10));
-        FusekiProjector projector = buildProjector(connector, source, dsg, 10, Duration.ofMillis(100), sink);
-
-        // When
-        projector.project(createTestDatasetEvent(), sink);
-        Thread.sleep(500);
-        // NB - We slept longer than our max transaction duration of 100 milliseconds, next projected event should
-        //      trigger a commit due to exceeding the duration
-        projector.project(createTestDatasetEvent(), sink);
-
-        // Then
-        Assertions.assertEquals(2L, sink.count());
-        verify(dsg, times(1)).begin((TxnType) any());
-        verify(dsg, times(1)).commit();
-    }
-
-    @Test
-    public void givenProjectorWithMaxTransactionDuration_whenReceivingEventsFasterThanMaxDuration_thenNoCommits() {
-        // Given
-        DatasetGraph dsg = mockDatasetGraph();
-        KConnectorDesc connector = createTestConnector();
-        NullSink<Event<Bytes, RdfPayload>> sink = NullSink.of();
-        EventSource<Bytes, RdfPayload> source = new InMemoryEventSource<>(createKafkaTestEvents(10));
-        FusekiProjector projector = buildProjector(connector, source, dsg, 1_000, Duration.ofMillis(100), sink);
-
-        // When
-        // NB - Intentionally 1 fewer than batch size, and source will have remaining events so shouldn't trigger
-        //      a commit, plus no sleeps so max duration should not be exceeded
-        for (int i = 1; i <= 999; i++) {
-            projector.project(createTestDatasetEvent(), sink);
-        }
-
-        // Then
-        Assertions.assertEquals(999L, sink.count());
-        verify(dsg, never()).commit();
     }
 }

--- a/jena-kafka-connector/src/test/java/org/apache/jena/kafka/common/TestFusekiProjector.java
+++ b/jena-kafka-connector/src/test/java/org/apache/jena/kafka/common/TestFusekiProjector.java
@@ -11,6 +11,7 @@ import io.telicent.smart.cache.sources.memory.InMemoryEventSource;
 import io.telicent.smart.cache.sources.memory.SimpleEvent;
 import org.apache.jena.kafka.JenaKafkaException;
 import org.apache.jena.kafka.KConnectorDesc;
+import org.apache.jena.kafka.SysJenaKafka;
 import org.apache.jena.rdfpatch.changes.RDFChangesCollector;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.DatasetGraphFactory;
@@ -70,7 +71,7 @@ public class TestFusekiProjector extends AbstractFusekiProjectorTests {
 
         // Then
         Assertions.assertNotNull(projector);
-        Assertions.assertEquals(FusekiProjector.DEFAULT_BATCH_SIZE, projector.getBatchSize());
+        Assertions.assertEquals(SysJenaKafka.DEFAULT_BATCH_SIZE, projector.getBatchSize());
     }
 
 
@@ -97,8 +98,8 @@ public class TestFusekiProjector extends AbstractFusekiProjectorTests {
 
         // Then
         Assertions.assertNotNull(projector);
-        Assertions.assertEquals(FusekiProjector.DEFAULT_BATCH_SIZE, projector.getBatchSize());
-        Assertions.assertEquals(FusekiProjector.DEFAULT_MAX_TRANSACTION_DURATION,
+        Assertions.assertEquals(SysJenaKafka.DEFAULT_BATCH_SIZE, projector.getBatchSize());
+        Assertions.assertEquals(SysJenaKafka.DEFAULT_MAX_TRANSACTION_DURATION,
                                 projector.getMaxTransactionDuration());
     }
 

--- a/jena-kafka-connector/src/test/java/org/apache/jena/kafka/common/TestFusekiProjectorHighLag.java
+++ b/jena-kafka-connector/src/test/java/org/apache/jena/kafka/common/TestFusekiProjectorHighLag.java
@@ -1,0 +1,141 @@
+package org.apache.jena.kafka.common;
+
+import io.telicent.smart.cache.payloads.RdfPayload;
+import io.telicent.smart.cache.projectors.sinks.NullSink;
+import io.telicent.smart.cache.sources.Event;
+import io.telicent.smart.cache.sources.EventSource;
+import io.telicent.smart.cache.sources.Header;
+import io.telicent.smart.cache.sources.TelicentHeaders;
+import io.telicent.smart.cache.sources.memory.SimpleEvent;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.jena.graph.Graph;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.query.TxnType;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFDataMgr;
+import org.apache.jena.riot.RDFWriter;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.core.DatasetGraphFactory;
+import org.apache.jena.sparql.graph.GraphFactory;
+import org.apache.kafka.common.utils.Bytes;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Supplier;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+public class TestFusekiProjectorHighLag extends AbstractFusekiProjectorTests {
+
+    private static final String NTRIPLES = Lang.NTRIPLES.getContentType().getContentTypeStr();
+
+    private EventSource<Bytes, RdfPayload> createHighVolumeSource(long maxRemaining, double multiplier) {
+        return createHighVolumeSource(maxRemaining, multiplier, AbstractFusekiProjectorTests::createTestDatasetEvent);
+    }
+
+    private EventSource<Bytes, RdfPayload> createHighVolumeSource(long maxRemaining, double multiplier,
+                                                                  Supplier<Event<Bytes, RdfPayload>> eventSupplier) {
+        return new RemainingVolumeSource(maxRemaining, multiplier, eventSupplier);
+    }
+
+
+    @Test
+    public void givenHighLagSource_whenProjectingLessThanBatchSize_thenHighLagDetected_andNoCommit() {
+        // Given
+        DatasetGraph dsg = mockDatasetGraph();
+        EventSource<Bytes, RdfPayload> source = createHighVolumeSource(50_000, 1);
+        FusekiProjector projector = buildProjector(createTestConnector(), source, dsg, 5_000);
+
+        // When
+        try (NullSink<Event<Bytes, RdfPayload>> sink = NullSink.of()) {
+            sendEvents(projector, source, sink, 2_500);
+        }
+
+        // Then
+        Assertions.assertTrue(projector.isHighLagDetected());
+        verify(dsg, times(1)).begin((TxnType) any());
+
+        // And
+        verify(dsg, never()).commit();
+    }
+
+    @Test
+    public void givenHighLagSource_whenProjectingBatchSizeEvents_thenHighLagDetected_andNoCommit() {
+        // Given
+        DatasetGraph dsg = mockDatasetGraph();
+        EventSource<Bytes, RdfPayload> source = createHighVolumeSource(50_000, 1);
+        FusekiProjector projector = buildProjector(createTestConnector(), source, dsg, 5_000);
+
+        // When
+        try (NullSink<Event<Bytes, RdfPayload>> sink = NullSink.of()) {
+            sendEvents(projector, source, sink, 5_000);
+        }
+
+        // Then
+        Assertions.assertTrue(projector.isHighLagDetected());
+        verify(dsg, times(1)).begin((TxnType) any());
+
+        // And
+        verify(dsg, never()).commit();
+    }
+
+    @Test
+    public void givenSourceWhoseLagEventuallyReachesZero_whenProjecting_thenHighLagDetectedInitially_andEventuallyDisabled() {
+        // Given
+        DatasetGraph dsg = mockDatasetGraph();
+        EventSource<Bytes, RdfPayload> source = createHighVolumeSource(15_000, 0.8);
+        FusekiProjector projector = buildProjector(createTestConnector(), source, dsg, 5_000);
+
+        // When
+        try (NullSink<Event<Bytes, RdfPayload>> sink = NullSink.of()) {
+            sendEvents(projector, source, sink, 5_000);
+
+            // Then
+            Assertions.assertTrue(projector.isHighLagDetected());
+
+            // And
+            while (!source.isExhausted()) {
+                sendEvents(projector, source, sink, 5_000);
+            }
+            Assertions.assertFalse(projector.isHighLagDetected());
+            verify(dsg, atLeastOnce()).begin((TxnType) any());
+            verify(dsg, atLeastOnce()).commit();
+        }
+    }
+
+    @Test
+    public void givenHighLagSource_whenProjectingLargeEvents_thenHighLagDetected_andCommitTriggeredByEventSize() {
+        // Given
+        DatasetGraph dsg = mockDatasetGraph();
+        Graph graph = GraphFactory.createGraphMem();
+        graph.add(NodeFactory.createURI("https://example.org/s"), NodeFactory.createURI("https://example.org/p"),
+                  NodeFactory.createLiteralString(RandomStringUtils.insecure().nextAlphanumeric(256 * 1024)));
+        byte[] graphData = RDFWriter.create()
+                                    .source(graph)
+                                    .lang(Lang.NTRIPLES)
+                                    .build()
+                                    .asString()
+                                    .getBytes(StandardCharsets.UTF_8);
+        Event<Bytes, RdfPayload> event =
+                new SimpleEvent<>(List.of(new Header(TelicentHeaders.CONTENT_TYPE, NTRIPLES)), null,
+                                  RdfPayload.of(NTRIPLES, graphData));
+        EventSource<Bytes, RdfPayload> source = createHighVolumeSource(50_000, 1, () -> event);
+        FusekiProjector projector = buildProjector(createTestConnector(), source, dsg, 5_000);
+
+        // When
+        try (NullSink<Event<Bytes, RdfPayload>> sink = NullSink.of()) {
+            sendEvents(projector, source, sink, 10_000);
+        }
+
+        // Then
+        Assertions.assertTrue(projector.isHighLagDetected());
+        verify(dsg, atLeastOnce()).begin((TxnType) any());
+
+        // And
+        verify(dsg, atLeastOnce()).commit();
+    }
+}

--- a/jena-kafka-connector/src/test/java/org/apache/jena/kafka/common/TestFusekiProjectorHighLag.java
+++ b/jena-kafka-connector/src/test/java/org/apache/jena/kafka/common/TestFusekiProjectorHighLag.java
@@ -12,17 +12,14 @@ import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.query.TxnType;
 import org.apache.jena.riot.Lang;
-import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.riot.RDFWriter;
 import org.apache.jena.sparql.core.DatasetGraph;
-import org.apache.jena.sparql.core.DatasetGraphFactory;
 import org.apache.jena.sparql.graph.GraphFactory;
 import org.apache.kafka.common.utils.Bytes;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Collections;
 import java.util.List;
 import java.util.function.Supplier;
 

--- a/jena-kafka-connector/src/test/java/org/apache/jena/kafka/common/TestFusekiProjectorLowVolume.java
+++ b/jena-kafka-connector/src/test/java/org/apache/jena/kafka/common/TestFusekiProjectorLowVolume.java
@@ -4,6 +4,7 @@ import io.telicent.smart.cache.payloads.RdfPayload;
 import io.telicent.smart.cache.projectors.sinks.NullSink;
 import io.telicent.smart.cache.sources.Event;
 import io.telicent.smart.cache.sources.EventSource;
+import org.apache.jena.kafka.SysJenaKafka;
 import org.apache.jena.query.TxnType;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.kafka.common.utils.Bytes;
@@ -31,17 +32,17 @@ public class TestFusekiProjectorLowVolume extends AbstractFusekiProjectorTests {
 
         // When
         try (NullSink<Event<Bytes, RdfPayload>> sink = NullSink.of()) {
-            sendEvents(projector, source, sink, FusekiProjector.RECENT_BATCH_SIZE_WINDOW);
+            sendEvents(projector, source, sink, SysJenaKafka.DEFAULT_BATCH_SIZE_TRACKING_WINDOW);
 
             // Then
             Assertions.assertTrue(projector.isLowVolumeDetected());
-            Assertions.assertEquals(FusekiProjector.RECENT_BATCH_SIZE_WINDOW, sink.count());
+            Assertions.assertEquals(SysJenaKafka.DEFAULT_BATCH_SIZE_TRACKING_WINDOW, sink.count());
             verify(dsg, times(25)).begin((TxnType) any());
             verify(dsg, times(25)).commit();
 
             // And
             sendEvents(projector, source, sink, 100);
-            Assertions.assertEquals(FusekiProjector.RECENT_BATCH_SIZE_WINDOW + 100, sink.count());
+            Assertions.assertEquals(SysJenaKafka.DEFAULT_BATCH_SIZE_TRACKING_WINDOW + 100, sink.count());
             verify(dsg, times(26)).begin((TxnType) any());
             verify(dsg, times(26)).commit();
         }
@@ -58,11 +59,11 @@ public class TestFusekiProjectorLowVolume extends AbstractFusekiProjectorTests {
 
         // When
         try (NullSink<Event<Bytes, RdfPayload>> sink = NullSink.of()) {
-            sendEvents(projector, source, sink, FusekiProjector.RECENT_BATCH_SIZE_WINDOW);
+            sendEvents(projector, source, sink, SysJenaKafka.DEFAULT_BATCH_SIZE_TRACKING_WINDOW);
 
             // Then
             Assertions.assertTrue(projector.isLowVolumeDetected());
-            Assertions.assertEquals(FusekiProjector.RECENT_BATCH_SIZE_WINDOW, sink.count());
+            Assertions.assertEquals(SysJenaKafka.DEFAULT_BATCH_SIZE_TRACKING_WINDOW, sink.count());
             verify(dsg, times(25)).begin((TxnType) any());
             verify(dsg, times(25)).commit();
 

--- a/jena-kafka-connector/src/test/java/org/apache/jena/kafka/common/TestFusekiProjectorLowVolume.java
+++ b/jena-kafka-connector/src/test/java/org/apache/jena/kafka/common/TestFusekiProjectorLowVolume.java
@@ -1,0 +1,123 @@
+package org.apache.jena.kafka.common;
+
+import io.telicent.smart.cache.payloads.RdfPayload;
+import io.telicent.smart.cache.projectors.sinks.NullSink;
+import io.telicent.smart.cache.sources.Event;
+import io.telicent.smart.cache.sources.EventSource;
+import org.apache.jena.query.TxnType;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.kafka.common.utils.Bytes;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+public class TestFusekiProjectorLowVolume extends AbstractFusekiProjectorTests {
+
+    private EventSource<Bytes, RdfPayload> createLowVolumeSource(long maxRemaining, double multiplier) {
+        return new RemainingVolumeSource(maxRemaining, multiplier,
+                                         AbstractFusekiProjectorTests::createTestDatasetEvent);
+    }
+
+    @Test
+    public void givenLowVolumeSource_whenProjecting_thenLowVolumeModeIsEngaged_andSubsequentEventsAreBatchedAppropriately() {
+        // Given
+        DatasetGraph dsg = mockDatasetGraph();
+        EventSource<Bytes, RdfPayload> source = createLowVolumeSource(1, 1);
+        FusekiProjector projector = buildProjector(createTestConnector(), source, dsg, 100);
+
+        // When
+        try (NullSink<Event<Bytes, RdfPayload>> sink = NullSink.of()) {
+            sendEvents(projector, source, sink, FusekiProjector.RECENT_BATCH_SIZE_WINDOW);
+
+            // Then
+            Assertions.assertTrue(projector.isLowVolumeDetected());
+            Assertions.assertEquals(FusekiProjector.RECENT_BATCH_SIZE_WINDOW, sink.count());
+            verify(dsg, times(25)).begin((TxnType) any());
+            verify(dsg, times(25)).commit();
+
+            // And
+            sendEvents(projector, source, sink, 100);
+            Assertions.assertEquals(FusekiProjector.RECENT_BATCH_SIZE_WINDOW + 100, sink.count());
+            verify(dsg, times(26)).begin((TxnType) any());
+            verify(dsg, times(26)).commit();
+        }
+    }
+
+    @Test
+    public void givenLowVolumeSource_whenProjectingWithShortMaxTransactionDuration_thenLowVolumeModeIsEngaged_andSubsequentEventsAreBatchedAppropriately() throws
+            InterruptedException {
+        // Given
+        DatasetGraph dsg = mockDatasetGraph();
+        EventSource<Bytes, RdfPayload> source = createLowVolumeSource(1, 1);
+        FusekiProjector projector =
+                buildProjector(createTestConnector(), source, dsg, 100, Duration.ofMillis(300), null);
+
+        // When
+        try (NullSink<Event<Bytes, RdfPayload>> sink = NullSink.of()) {
+            sendEvents(projector, source, sink, FusekiProjector.RECENT_BATCH_SIZE_WINDOW);
+
+            // Then
+            Assertions.assertTrue(projector.isLowVolumeDetected());
+            Assertions.assertEquals(FusekiProjector.RECENT_BATCH_SIZE_WINDOW, sink.count());
+            verify(dsg, times(25)).begin((TxnType) any());
+            verify(dsg, times(25)).commit();
+
+            // And
+            sendEvents(projector, source, sink, 1);
+            Thread.sleep(500);
+            sendEvents(projector, source, sink, 1);
+            verify(dsg, times(26)).begin((TxnType) any());
+            verify(dsg, times(26)).commit();
+        }
+    }
+
+    @Test
+    public void givenLowVolumeSourceThatEventuallyGetsHighVolume_whenProjecting_thenLowVolumeModeIsEngagedInitially_andSubsequentlyDisengaged() {
+        // Given
+        DatasetGraph dsg = mockDatasetGraph();
+        EventSource<Bytes, RdfPayload> source = createLowVolumeSource(1, 1.1);
+        FusekiProjector projector = buildProjector(createTestConnector(), source, dsg, 100);
+
+        // When
+        try (NullSink<Event<Bytes, RdfPayload>> sink = NullSink.of()) {
+            while (!projector.isLowVolumeDetected()) {
+                sendEvents(projector, source, sink, Math.max(1, source.remaining().intValue()));
+            }
+
+            // Then
+            verify(dsg, atLeastOnce()).begin((TxnType) any());
+            verify(dsg, atLeastOnce()).commit();
+
+            // And
+            while (projector.isLowVolumeDetected()) {
+                sendEvents(projector, source, sink, Math.max(1, source.remaining().intValue()));
+            }
+        }
+    }
+
+    @Test
+    public void givenSourceWhoseVolumeEventuallyBecomesLow_whenProjecting_thenLowVolumeModeEventuallyEngaged() {
+        // Given
+        DatasetGraph dsg = mockDatasetGraph();
+        EventSource<Bytes, RdfPayload> source = createLowVolumeSource(10_000, 0.95);
+        FusekiProjector projector = buildProjector(createTestConnector(), source, dsg, 100);
+
+        // When
+        try (NullSink<Event<Bytes, RdfPayload>> sink = NullSink.of()) {
+            while (!source.isExhausted()) {
+                sendEvents(projector, source, sink, Math.max(1, source.remaining().intValue()));
+            }
+
+            // Then
+            verify(dsg, atLeastOnce()).begin((TxnType) any());
+            verify(dsg, atLeastOnce()).commit();
+            Assertions.assertTrue(projector.isLowVolumeDetected());
+
+        }
+    }
+
+}

--- a/jena-kafka-connector/src/test/java/org/apache/jena/kafka/common/TestFusekiProjectorWithKafkaEvents.java
+++ b/jena-kafka-connector/src/test/java/org/apache/jena/kafka/common/TestFusekiProjectorWithKafkaEvents.java
@@ -1,0 +1,160 @@
+package org.apache.jena.kafka.common;
+
+import io.telicent.smart.cache.payloads.RdfPayload;
+import io.telicent.smart.cache.projectors.Sink;
+import io.telicent.smart.cache.projectors.SinkException;
+import io.telicent.smart.cache.projectors.sinks.NullSink;
+import io.telicent.smart.cache.sources.Event;
+import io.telicent.smart.cache.sources.EventSource;
+import io.telicent.smart.cache.sources.kafka.KafkaEvent;
+import io.telicent.smart.cache.sources.memory.InMemoryEventSource;
+import io.telicent.smart.cache.sources.memory.SimpleEvent;
+import org.apache.jena.kafka.JenaKafkaException;
+import org.apache.jena.kafka.KConnectorDesc;
+import org.apache.jena.query.TxnType;
+import org.apache.jena.rdfpatch.changes.RDFChangesCollector;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.core.DatasetGraphFactory;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.utils.Bytes;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+public class TestFusekiProjectorWithKafkaEvents extends AbstractFusekiProjectorTests {
+
+
+    private List<Event<Bytes, RdfPayload>> createKafkaTestEvents(int size) {
+        List<Event<Bytes, RdfPayload>> events = new ArrayList<>();
+        for (int i = 0; i < size; i++) {
+            ConsumerRecord<Bytes, RdfPayload> record = new ConsumerRecord<>("test", 0, i, Bytes.wrap(new byte[0]),
+                                                                            RdfPayload.of(
+                                                                                    TestFusekiSink.createSimpleDatasetPayload()));
+            events.add(new KafkaEvent<>(record, null));
+        }
+        return events;
+    }
+
+    @Test
+    public void givenBatchingProjector_whenProjectingKafkaEventsEquallingBatchSize_thenProjectedWithSingleTransaction() {
+        // Given
+        KConnectorDesc connector = createTestConnector();
+        List<Event<Bytes, RdfPayload>> kafkaEvents = createKafkaTestEvents(3);
+        EventSource<Bytes, RdfPayload> source = new InMemoryEventSource<>(kafkaEvents);
+        DatasetGraph dsg = mockDatasetGraph();
+        FusekiProjector projector = buildProjector(connector, source, dsg, 3);
+
+        // When and Then
+        verifyProjection(source, projector, dsg, 3, 1, 1);
+    }
+
+    @Test
+    public void givenProjector_whenProjectingMalformedRdfPayloadKafkaEvent_thenNoTransaction() {
+        // Given
+        KConnectorDesc connector = createTestConnector();
+        EventSource<Bytes, RdfPayload> source = new InMemoryEventSource<>(
+                List.of(new KafkaEvent<>(new ConsumerRecord<>("test", 0, 0, Bytes.wrap(new byte[0]),
+                                                              RdfPayload.of("text/unrecognized", new byte[100])),
+                                         null)));
+        DatasetGraph dsg = mockDatasetGraph();
+        FusekiProjector projector = buildProjector(connector, source, dsg, 1);
+
+        // When and Then
+        Assertions.assertThrows(JenaKafkaException.class,
+                                () -> verifyFusekiSinkProjection(source, projector, dsg, 0, 0, 0));
+        verifyNoTransactions(dsg);
+    }
+
+    @Test
+    public void givenProjectorInTransaction_whenStalling_thenCommits() {
+        // Given
+        DatasetGraph dsg = mockDatasetGraph();
+        KConnectorDesc connector = createTestConnector();
+        NullSink<Event<Bytes, RdfPayload>> sink = NullSink.of();
+        EventSource<Bytes, RdfPayload> source = new InMemoryEventSource<>(createKafkaTestEvents(10));
+        FusekiProjector projector = buildProjector(connector, source, dsg, 10, sink);
+
+        // When
+        projector.project(createTestDatasetEvent(), sink);
+        projector.stalled(sink);
+
+        // Then
+        Assertions.assertEquals(1L, sink.count());
+        verify(dsg, times(1)).begin((TxnType) any());
+        verify(dsg, times(1)).commit();
+    }
+
+    @Test
+    public void givenNonBatchingProjector_whenStalling_thenNoAdditionalCommits() {
+        // Given
+        DatasetGraph dsg = mockDatasetGraph();
+        KConnectorDesc connector = createTestConnector();
+        NullSink<Event<Bytes, RdfPayload>> sink = NullSink.of();
+        EventSource<Bytes, RdfPayload> source = new InMemoryEventSource<>(createKafkaTestEvents(10));
+        FusekiProjector projector = buildProjector(connector, source, dsg, 1, sink);
+
+        // When
+        projector.project(createTestDatasetEvent(), sink);
+        projector.stalled(sink);
+
+        // Then
+        Assertions.assertEquals(1L, sink.count());
+        verify(dsg, times(1)).begin((TxnType) any());
+        verify(dsg, times(1)).commit();
+    }
+
+    @Test
+    public void givenProjectorWithMaxTransactionDuration_whenReceivingEventsSlowly_thenCommitsTriggeredByTimeThreshold() throws
+            InterruptedException {
+        // Given
+        DatasetGraph dsg = mockDatasetGraph();
+        KConnectorDesc connector = createTestConnector();
+        NullSink<Event<Bytes, RdfPayload>> sink = NullSink.of();
+        EventSource<Bytes, RdfPayload> source = new InMemoryEventSource<>(createKafkaTestEvents(10));
+        FusekiProjector projector = buildProjector(connector, source, dsg, 10, Duration.ofMillis(100), sink);
+
+        // When
+        projector.project(createTestDatasetEvent(), sink);
+        Thread.sleep(500);
+        // NB - We slept longer than our max transaction duration of 100 milliseconds, next projected event should
+        //      trigger a commit due to exceeding the duration
+        projector.project(createTestDatasetEvent(), sink);
+
+        // Then
+        Assertions.assertEquals(2L, sink.count());
+        verify(dsg, times(1)).begin((TxnType) any());
+        verify(dsg, times(1)).commit();
+    }
+
+    @Test
+    public void givenProjectorWithMaxTransactionDuration_whenReceivingEventsFasterThanMaxDuration_thenNoCommits() {
+        // Given
+        DatasetGraph dsg = mockDatasetGraph();
+        KConnectorDesc connector = createTestConnector();
+        NullSink<Event<Bytes, RdfPayload>> sink = NullSink.of();
+        EventSource<Bytes, RdfPayload> source = new InMemoryEventSource<>(createKafkaTestEvents(10));
+        FusekiProjector projector = buildProjector(connector, source, dsg, 1_000, Duration.ofMillis(100), sink);
+
+        // When
+        // NB - Intentionally 1 fewer than batch size, and source will have remaining events so shouldn't trigger
+        //      a commit, plus no sleeps so max duration should not be exceeded
+        for (int i = 1; i <= 999; i++) {
+            projector.project(createTestDatasetEvent(), sink);
+        }
+
+        // Then
+        Assertions.assertEquals(999L, sink.count());
+        verify(dsg, never()).commit();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,7 @@
         <dependency.commons-beanutils>1.11.0</dependency.commons-beanutils>
         <dependency.commons-io>2.20.0</dependency.commons-io>
         <dependency.commons-lang>3.18.0</dependency.commons-lang>
+        <dependency.commons-math>3.6.1</dependency.commons-math>
         <dependency.kafka>3.9.1</dependency.kafka>
         <dependency.log4j2>2.25.1</dependency.log4j2>
         <dependency.lombok>1.18.38</dependency.lombok>


### PR DESCRIPTION
This PR addresses two edge cases in batching behaviour observed on our clusters:

1. A slow low volume producer leading to lots of small batches of a few events
2. Very high lag leading to lots of transactions

The `FusekiProjector` is improved to be able to detect both these cases, with configurable thresholds, and changes its batching behaviour accordingly.

In low volume mode stops committing when lag is zero, committing only when batch size or max transaction duration is reached.

In high lag mode ignores configured batch size, committing only when batch size in bytes exceeds a threshold or another batching threshold (lag 0 reached, max transaction duration exceeded) is reached.

Both modes aim to decrease the number of transactions in these scenarios to improve performance.   Both modes automatically disable themselves when they are no longer applicable.  Configuration parameters for all the thresholds around these allow these modes to be tuned/disabled based on actual observed conditions on user workloads.