### PR TITLE
Minor improvements

### DIFF
--- a/jena-fuseki-kafka-module/src/main/java/org/apache/jena/fuseki/kafka/FKS.java
+++ b/jena-fuseki-kafka-module/src/main/java/org/apache/jena/fuseki/kafka/FKS.java
@@ -252,6 +252,9 @@ public class FKS {
                                .unlimited()
                                .reportBatchSize(10_000)
                                .source(source)
+                               // Label each driver with the topics it pertains to, this makes the logs easier to read
+                               // if there are multiple connectors defined
+                               .logLabel("[" + StringUtils.join(connector.getTopics(), ", ") + "]")
                                .projector(FusekiProjector.builder()
                                                          .source(source)
                                                          .dataset(destination)

--- a/jena-kafka-connector/src/main/java/org/apache/jena/kafka/common/FusekiSink.java
+++ b/jena-kafka-connector/src/main/java/org/apache/jena/kafka/common/FusekiSink.java
@@ -68,6 +68,7 @@ public class FusekiSink<T extends DatasetGraph> implements Sink<Event<Bytes, Rdf
      */
     protected void applyDatasetEvent(Event<Bytes, RdfPayload> event) {
         event.value().getDataset().stream().forEach(this.dataset::add);
+
     }
 
     @Override

--- a/jena-kafka-connector/src/test/java/org/apache/jena/kafka/common/AbstractFusekiProjectorTests.java
+++ b/jena-kafka-connector/src/test/java/org/apache/jena/kafka/common/AbstractFusekiProjectorTests.java
@@ -155,7 +155,7 @@ public class AbstractFusekiProjectorTests {
     }
 
     protected static void sendEvents(FusekiProjector projector, EventSource<Bytes, RdfPayload> source,
-                                     NullSink<Event<Bytes, RdfPayload>> sink, int count) {
+                                     Sink<Event<Bytes, RdfPayload>> sink, int count) {
         for (int i = 0; i < count; i++) {
             if (source.isExhausted()) return;
             Event<Bytes, RdfPayload> event = source.poll(Duration.ofSeconds(3));

--- a/jena-kafka-connector/src/test/resources/logback-test.xml
+++ b/jena-kafka-connector/src/test/resources/logback-test.xml
@@ -27,7 +27,7 @@
     <!-- Jena's Debug level gets very noisy -->
     <!--<logger name="org.apache.jena" level="INFO" />-->
 
-    <root level="DEBUG">
+    <root level="OFF">
         <appender-ref ref="STDERR" />
     </root>
 </configuration>

--- a/jena-kafka-connector/src/test/resources/logback-test.xml
+++ b/jena-kafka-connector/src/test/resources/logback-test.xml
@@ -27,7 +27,7 @@
     <!-- Jena's Debug level gets very noisy -->
     <!--<logger name="org.apache.jena" level="INFO" />-->
 
-    <root level="OFF">
+    <root level="DEBUG">
         <appender-ref ref="STDERR" />
     </root>
 </configuration>


### PR DESCRIPTION
A couple of minor improvements:

1. Keep current batch size in bytes as a running counter rather than calculating it repeatedly
2. Add log label of `[<topic>]` to `ProjectorDriver` instances to make logs clearer when multiple connectors are running