### PR TITLE
Complete Release 3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Kafka Connector for Apache Jena Fuseki
 
+## 3.0.1
+
+- Build improvements:
+    - Jetty upgraded to 12.1.7
+    - Lombok upgraded to 1.18.44
+    - LZ4 Java upgraded to 1.10.4
+    - Smart Caches Core upgraded to 0.36.2
+    - Various build and test dependencies upgraded to latest available
+
 ## 3.0.0
 
 - Added optional missing topic checks during startup

--- a/jena-fmod-kafka/pom.xml
+++ b/jena-fmod-kafka/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>io.telicent.jena</groupId>
     <artifactId>jena-kafka</artifactId>
-    <version>3.0.1</version>
+    <version>3.0.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent> 
 
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>io.telicent.jena</groupId>
       <artifactId>jena-fuseki-kafka-module</artifactId>
-      <version>3.0.1</version>
+      <version>3.0.2-SNAPSHOT</version>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>

--- a/jena-fmod-kafka/pom.xml
+++ b/jena-fmod-kafka/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>io.telicent.jena</groupId>
     <artifactId>jena-kafka</artifactId>
-    <version>3.0.1-SNAPSHOT</version>
+    <version>3.0.1</version>
     <relativePath>..</relativePath>
   </parent> 
 
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>io.telicent.jena</groupId>
       <artifactId>jena-fuseki-kafka-module</artifactId>
-      <version>3.0.1-SNAPSHOT</version>
+      <version>3.0.1</version>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>

--- a/jena-fuseki-kafka-module/pom.xml
+++ b/jena-fuseki-kafka-module/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>io.telicent.jena</groupId>
     <artifactId>jena-kafka</artifactId>
-    <version>3.0.1-SNAPSHOT</version>
+    <version>3.0.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/jena-fuseki-kafka-module/pom.xml
+++ b/jena-fuseki-kafka-module/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>io.telicent.jena</groupId>
     <artifactId>jena-kafka</artifactId>
-    <version>3.0.1</version>
+    <version>3.0.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/jena-kafka-connector/pom.xml
+++ b/jena-kafka-connector/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>io.telicent.jena</groupId>
         <artifactId>jena-kafka</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/jena-kafka-connector/pom.xml
+++ b/jena-kafka-connector/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>io.telicent.jena</groupId>
         <artifactId>jena-kafka</artifactId>
-        <version>3.0.1-SNAPSHOT</version>
+        <version>3.0.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <groupId>io.telicent.jena</groupId>
     <artifactId>jena-kafka</artifactId>
     <packaging>pom</packaging>
-    <version>3.0.1-SNAPSHOT</version>
+    <version>3.0.1</version>
 
     <name>Apache Jena Fuseki-Kafka Connector</name>
     <description>Fuseki Module : Kafka Connector</description>
@@ -51,7 +51,7 @@
         <connection>scm:git:git@github.com:telicent-oss/jena-fuseki-kafka</connection>
         <developerConnection>scm:git:git@github.com:telicent-oss/jena-fuseki-kafka</developerConnection>
         <url>https://github.com/telicent-oss/jena-fuseki-kafka</url>
-        <tag>1.3.2</tag>
+        <tag>3.0.1</tag>
     </scm>
 
     <properties>
@@ -59,7 +59,7 @@
         <build.time.xsd>${maven.build.timestamp}</build.time.xsd>
         <java.version>21</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.build.outputTimestamp>2026-03-03T15:40:18Z</project.build.outputTimestamp>
+        <project.build.outputTimestamp>2026-03-26T09:47:27Z</project.build.outputTimestamp>
         <coverage.minimum>0.8</coverage.minimum>
         <test.maxForks>2</test.maxForks>
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <groupId>io.telicent.jena</groupId>
     <artifactId>jena-kafka</artifactId>
     <packaging>pom</packaging>
-    <version>3.0.1</version>
+    <version>3.0.2-SNAPSHOT</version>
 
     <name>Apache Jena Fuseki-Kafka Connector</name>
     <description>Fuseki Module : Kafka Connector</description>
@@ -51,7 +51,7 @@
         <connection>scm:git:git@github.com:telicent-oss/jena-fuseki-kafka</connection>
         <developerConnection>scm:git:git@github.com:telicent-oss/jena-fuseki-kafka</developerConnection>
         <url>https://github.com/telicent-oss/jena-fuseki-kafka</url>
-        <tag>3.0.1</tag>
+        <tag>1.3.2</tag>
     </scm>
 
     <properties>
@@ -59,7 +59,7 @@
         <build.time.xsd>${maven.build.timestamp}</build.time.xsd>
         <java.version>21</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.build.outputTimestamp>2026-03-26T09:47:27Z</project.build.outputTimestamp>
+        <project.build.outputTimestamp>2026-03-26T09:57:04Z</project.build.outputTimestamp>
         <coverage.minimum>0.8</coverage.minimum>
         <test.maxForks>2</test.maxForks>
 


### PR DESCRIPTION
Once again Maven Central publishing timed out on the GitHub Actions side but did eventually complete successfully on Maven Central side but means automated PR creation didn't happen so had to create manually

## Version 3.0.1

- Build improvements:
    - Jetty upgraded to 12.1.7
    - Lombok upgraded to 1.18.44
    - LZ4 Java upgraded to 1.10.4
    - Smart Caches Core upgraded to 0.36.2
    - Various build and test dependencies upgraded to latest available