### PR TITLE
More graceful state file upgrade (CORE-1149)

### DIFF
--- a/jena-kafka-connector/src/main/java/org/apache/jena/kafka/common/FusekiOffsetStore.java
+++ b/jena-kafka-connector/src/main/java/org/apache/jena/kafka/common/FusekiOffsetStore.java
@@ -9,6 +9,7 @@ import io.telicent.smart.cache.sources.kafka.KafkaEventSource;
 import io.telicent.smart.cache.sources.offsets.MemoryOffsetStore;
 import lombok.*;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.jena.kafka.JenaKafkaException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -167,7 +168,10 @@ public class FusekiOffsetStore extends MemoryOffsetStore {
                 }
 
                 // Configuration sanity checks
-                if (!this.datasetName.equals(datasetName)) {
+                // NB - To allow graceful migration if the stored datasetName has trailing URL segments vs the currently
+                // configured one then permit this
+                if (!this.datasetName.equals(datasetName) && !Strings.CS.startsWith(datasetName, this.datasetName + (
+                        this.datasetName.endsWith("/") ? "" : "/"))) {
                     throw new JenaKafkaException(
                             "Dataset name does not match: this=" + this.datasetName + " / read=" + datasetName);
                 }

--- a/jena-kafka-connector/src/test/java/org/apache/jena/kafka/common/TestFusekiOffsetStore.java
+++ b/jena-kafka-connector/src/test/java/org/apache/jena/kafka/common/TestFusekiOffsetStore.java
@@ -112,7 +112,7 @@ public class TestFusekiOffsetStore {
             IOException {
         // Given
         String datasetName = DATASET_NAME;
-        Map<String, Object> legacyState = Map.of(FusekiOffsetStore.FIELD_DATASET, datasetName + "/upload",
+        Map<String, Object> legacyState = Map.of(FusekiOffsetStore.FIELD_DATASET, "/other",
                                                  FusekiOffsetStore.LEGACY_FIELD_ENDPOINT, "foo",
                                                  FusekiOffsetStore.LEGACY_FIELD_TOPIC, "test",
                                                  FusekiOffsetStore.LEGACY_FIELD_OFFSET, 1234L);
@@ -130,10 +130,45 @@ public class TestFusekiOffsetStore {
         Assertions.assertTrue(StringUtils.contains(e.getMessage(), "Dataset name does not match"));
     }
 
+    @Test
+    public void givenLegacyStateFileWithPrefixDatasetName_whenCreatingStore_thenConversionSucceeds_andAfterSavePrefixIsRemoved() throws
+            IOException {
+        // Given
+        String datasetName = DATASET_NAME;
+        Map<String, Object> legacyState = Map.of(FusekiOffsetStore.FIELD_DATASET, datasetName + "/upload",
+                                                 FusekiOffsetStore.LEGACY_FIELD_ENDPOINT, "foo",
+                                                 FusekiOffsetStore.LEGACY_FIELD_TOPIC, "test",
+                                                 FusekiOffsetStore.LEGACY_FIELD_OFFSET, 1234L);
+        File stateFile = createStateFile(legacyState);
+
+        // When and Then
+        FusekiOffsetStore store = FusekiOffsetStore.builder()
+                                                   .datasetName(
+                                                           datasetName)
+                                                   .stateFile(
+                                                           stateFile)
+                                                   .consumerGroup(
+                                                           "example")
+                                                   .build();
+        Assertions.assertNotNull(store);
+        Assertions.assertEquals(datasetName, store.getDatasetName());
+
+        // And
+        store.close();
+        Map<String, Object> convertedState = loadStateFile(stateFile);
+        Assertions.assertEquals(datasetName, convertedState.get(FusekiOffsetStore.FIELD_DATASET));
+
+    }
+
     private File createStateFile(Map<String, Object> state) throws IOException {
         File stateFile = Files.createTempFile("state", ".json").toFile();
         writeStateFile(state, stateFile);
         return stateFile;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> loadStateFile(File stateFile) throws IOException {
+        return this.mapper.readValue(stateFile, Map.class);
     }
 
     private void writeStateFile(Map<String, Object> state, File stateFile) throws IOException {


### PR DESCRIPTION
In course of testing CORE-1149 was making various changes to the SC-Graph configuration file and noticed that I couldn't modernise some of the configuration because it had been migrated from the legacy configuration which allowed for trailing path segements on dataset names.  This commit allows the configured dataset name to be a starting prefix of the stored dataset name which enables more graceful migration to the modern supported configuration.