### PR TITLE
[CORE-551] Common Kafka connector config

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,49 @@ PREFIX ja:      <http://jena.hpl.hp.com/2005/11/Assembler#>
     .
 ```
 
+### Shared Cluster Configuration
+
+When you have multiple connectors that all talk to the same Kafka cluster, the connection settings (bootstrap servers
+and any `fk:config`/`fk:configFile` properties) would otherwise have to be repeated on every connector.  Instead you can
+declare them once on a shared `fk:Cluster` and have each connector reference it via `fk:cluster`:
+
+```
+<#cluster> rdf:type fk:Cluster ;
+    fk:bootstrapServers  "localhost:9092" ;
+    fk:config            ( "security.protocol" "SSL" ) ;
+    fk:configFile        "/app/kafka.properties" .
+
+<#connector1> rdf:type fk:Connector ;
+    fk:cluster           <#cluster> ;
+    fk:topic             "example" ;
+    fk:fusekiServiceName "/s1" ;
+    fk:stateFile         "/data/s1.state" .
+
+<#connector2> rdf:type fk:Connector ;
+    fk:cluster           <#cluster> ;
+    fk:topic             "another" ;
+    fk:fusekiServiceName "/s2" ;
+    fk:stateFile         "/data/s2.state" .
+```
+
+The following design choices apply:
+
+- **Only connection settings are inherited.** A connector inherits `fk:bootstrapServers`, `fk:config` and
+  `fk:configFile` from its cluster. Everything else (`fk:topic`, `fk:fusekiServiceName`, `fk:stateFile`, `fk:dlqTopic`,
+  the sync/replay flags, etc.) is always declared per-connector.
+- **The connector wins.** If the same setting is declared on both the connector and its cluster, the connector's value
+  takes precedence. For the `fk:config`/`fk:configFile` properties the values are merged, with the connector's entries
+  overriding the cluster's on a per-key basis. The effective precedence order, lowest to highest, is: cluster
+  `fk:config`, cluster `fk:configFile`, connector `fk:config`, connector `fk:configFile`.
+- **The consumer group is never inherited.** `fk:groupId` is deliberately *not* inheritable from the cluster, because
+  every connector requires its own unique Kafka consumer group (see the note on `fk:groupId` above). Declare it on each
+  connector if you need a non-default value.
+- **Bootstrap servers are required somewhere.** If neither the connector nor its cluster supplies
+  `fk:bootstrapServers`, the connector fails to load with a clear error.
+- **Environment variables still work.** Values declared on the cluster support the same `env:` indirection as values
+  declared directly on a connector.
+- A connector may reference at most one cluster, and different connectors may reference different clusters.
+
 ### Kafka Read Behaviour
 
 Note that the Fuseki Kafka Module by default starts the Kafka connectors prior to the Fuseki HTTP Server starting,

--- a/jena-kafka-connector/src/main/java/org/apache/jena/kafka/KafkaConnectorAssembler.java
+++ b/jena-kafka-connector/src/main/java/org/apache/jena/kafka/KafkaConnectorAssembler.java
@@ -48,6 +48,7 @@ import org.apache.jena.riot.out.NodeFmtLib;
 import org.apache.jena.sparql.engine.binding.Binding;
 import org.apache.jena.sparql.exec.QueryExec;
 import org.apache.jena.sparql.exec.RowSet;
+import org.apache.jena.system.G;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -81,6 +82,29 @@ import org.slf4j.LoggerFactory;
  *   fk:stateFile           "Databases/RDF.state";
  *    .
  * </pre>
+ * <p>
+ * Common Kafka settings can be declared once on a shared {@code fk:Cluster} and reused by multiple connectors via
+ * {@code fk:cluster}, avoiding duplication between connectors:
+ * </p>
+ * <pre>
+ * &lt;#cluster&gt; rdf:type fk:Cluster ;
+ *   fk:bootstrapServers  "localhost:9092" ;
+ *   fk:config            ( "security.protocol" "SSL" ) ;
+ *   fk:configFile        "/app/kafka.properties" .
+ *
+ * &lt;#connector1&gt; rdf:type fk:Connector ;
+ *   fk:cluster           &lt;#cluster&gt; ;
+ *   fk:topic             "example" ;
+ *   fk:fusekiServiceName "/s1" ;
+ *   fk:stateFile         "/data/s1.state" .
+ * </pre>
+ * <p>
+ * Only the connection-level settings are inherited from the cluster: {@code fk:bootstrapServers}, {@code fk:config}
+ * and {@code fk:configFile}.  Everything else - including {@code fk:topic}, {@code fk:fusekiServiceName},
+ * {@code fk:stateFile} and {@code fk:groupId} - remains per-connector.  In particular {@code fk:groupId} is
+ * deliberately not inherited because each connector requires its own unique Kafka consumer group.  Where a setting is
+ * present on both the connector and its cluster, the connector's value takes precedence.
+ * </p>
  */
 public class KafkaConnectorAssembler extends AssemblerBase implements Assembler {
 
@@ -93,6 +117,12 @@ public class KafkaConnectorAssembler extends AssemblerBase implements Assembler 
      * RDF Type for Kafka connectors
      */
     public static Resource tKafkaConnector = ResourceFactory.createResource(NS + "Connector");
+
+    /**
+     * RDF Type for a shared Kafka cluster configuration that connectors may reference (via {@link #pCluster}) to
+     * inherit common connection settings
+     */
+    public static Resource tKafkaCluster = ResourceFactory.createResource(NS + "Cluster");
 
     // Preferred:   "fusekiServiceName"
 
@@ -129,6 +159,11 @@ public class KafkaConnectorAssembler extends AssemblerBase implements Assembler 
     private static final Node pReplayTopic = NodeFactory.createURI(NS + "replayTopic");
 
     // Kafka cluster
+    /**
+     * Links a connector to a shared {@link #tKafkaCluster} whose common Kafka settings (bootstrap servers and
+     * {@code config}/{@code configFile} properties) the connector inherits
+     */
+    public static Node pCluster = NodeFactory.createURI(NS + "cluster");
     public static Node pKafkaProperty = NodeFactory.createURI(NS + "config");
     public static Node pKafkaPropertyFile = NodeFactory.createURI(NS + "configFile");
     public static Node pKafkaBootstrapServers = NodeFactory.createURI(NS + "bootstrapServers");
@@ -190,7 +225,21 @@ public class KafkaConnectorAssembler extends AssemblerBase implements Assembler 
         String datasetName = datasetName(graph, node);
         datasetName = /*DataAccessPoint.*/canonical(datasetName);
 
-        String bootstrapServers = getConfigurationValue(graph, node, pKafkaBootstrapServers, errorException);
+        // A connector may reference a shared cluster definition (fk:cluster) to inherit common Kafka settings.  Only
+        // the connection-level settings - bootstrap servers and the config/configFile properties - are inherited;
+        // everything else (topic, service name, state file, group id, etc.) remains per-connector by design.  In
+        // particular the Kafka consumer group id is deliberately NOT inherited as each connector requires its own
+        // unique consumer group.
+        Node cluster = G.getZeroOrOneSP(graph, node, pCluster);
+
+        // Bootstrap servers: use the connector's value if present, otherwise fall back to the cluster's value.
+        String bootstrapServers =
+                getInheritedConfigurationValue(graph, node, cluster, pKafkaBootstrapServers, errorException);
+        if (StringUtils.isBlank(bootstrapServers)) {
+            throw onError(node, pKafkaBootstrapServers,
+                          "No bootstrap servers configured on the connector or its referenced fk:cluster",
+                          errorException);
+        }
 
         boolean syncTopic = Assem2.getBooleanOrDft(graph, node, pSyncTopic, DEFAULT_SYNC_TOPIC, errorException);
         boolean replayTopic = Assem2.getBooleanOrDft(graph, node, pReplayTopic, DEFAULT_REPLAY_TOPIC, errorException);
@@ -217,16 +266,39 @@ public class KafkaConnectorAssembler extends AssemblerBase implements Assembler 
         String dlqTopic = getConfigurationValueOrDefault(graph, node, pDlqTopic, null, errorException);
 
         // ----
-        Properties kafkaConsumerProps = kafkaConsumerProps(graph, node, bootstrapServers, groupId);
+        Properties kafkaConsumerProps = kafkaConsumerProps(graph, node, cluster, bootstrapServers, groupId);
         return new KConnectorDesc(topics, bootstrapServers, datasetName, stateFile, syncTopic, replayTopic,
                                   startupTopicCheck, dlqTopic, kafkaConsumerProps);
     }
 
-    private Properties kafkaConsumerProps(Graph graph, Node node, String bootstrapServers, String groupId) {
+    private Properties kafkaConsumerProps(Graph graph, Node node, Node cluster, String bootstrapServers,
+                                          String groupId) {
         Properties props = SysJenaKafka.consumerProperties(bootstrapServers);
         // "group.id"
         props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
 
+        // Layer configuration in increasing order of precedence so that a connector can override its cluster:
+        //   1. shared cluster inline config   (fk:config on the cluster)
+        //   2. shared cluster config file(s)  (fk:configFile on the cluster)
+        //   3. connector inline config        (fk:config on the connector)
+        //   4. connector config file(s)       (fk:configFile on the connector)
+        // Within each level the config file is applied after the inline pairs, so a file overrides inline values; this
+        // matches the long-standing single-connector behaviour.
+        if (cluster != null) {
+            applyInlineKafkaConfig(graph, cluster, props);
+            applyKafkaConfigFiles(graph, cluster, props);
+        }
+        applyInlineKafkaConfig(graph, node, props);
+        applyKafkaConfigFiles(graph, node, props);
+
+        return props;
+    }
+
+    /**
+     * Applies inline Kafka configuration declared as {@code fk:config} {@code (key value)} RDF list pairs on the given
+     * node to the supplied properties.
+     */
+    private void applyInlineKafkaConfig(Graph graph, Node node, Properties props) {
         // Optional Kafka configuration as pairs of (key-value) as RDF lists.
         String queryString = StrUtils.strjoinNL("PREFIX ja: <" + JA.getURI() + ">", "SELECT ?k ?v { ?X ?P (?k ?v) }");
 
@@ -244,8 +316,13 @@ public class KafkaConnectorAssembler extends AssemblerBase implements Assembler 
                     props.setProperty(key, value);
                 });
         }
+    }
 
-        // External Kafka Properties File
+    /**
+     * Applies external Kafka properties file(s) declared as {@code fk:configFile} on the given node to the supplied
+     * properties.
+     */
+    private void applyKafkaConfigFiles(Graph graph, Node node, Properties props) {
         graph.stream(node, pKafkaPropertyFile, Node.ANY).map(Triple::getObject).forEach(propertyFile -> {
             if (propertyFile.isURI()) {
                 if (propertyFile.getURI().startsWith("file:")) {
@@ -261,8 +338,6 @@ public class KafkaConnectorAssembler extends AssemblerBase implements Assembler 
                 badPropertiesFileValue(node);
             }
         });
-
-        return props;
     }
 
     private static void badPropertiesFileValue(Node node) {
@@ -359,6 +434,30 @@ public class KafkaConnectorAssembler extends AssemblerBase implements Assembler 
     static String getConfigurationValue(Graph graph, Node node, Node property, Assem2.OnError errorException) {
         String configurationValue = Assem2.getString(graph, node, property, errorException);
         configurationValue = checkForEnvironmentVariableValue(property.getURI(), configurationValue);
+        return configurationValue;
+    }
+
+    /**
+     * Gets a single configuration value from the connector node, falling back to the referenced cluster node (if any)
+     * when the connector does not set it.  Any environment variable indirection is resolved.  Returns {@code null} if
+     * the value is set in neither place.
+     *
+     * @param graph          Configuration graph
+     * @param node           Connector node
+     * @param cluster        Referenced cluster node, or {@code null} if the connector references no cluster
+     * @param property       Property to read
+     * @param errorException Error generator
+     * @return Resolved value, or {@code null} if absent from both connector and cluster
+     */
+    static String getInheritedConfigurationValue(Graph graph, Node node, Node cluster, Node property,
+                                                 Assem2.OnError errorException) {
+        String configurationValue = Assem2.getStringOrDft(graph, node, property, null, errorException);
+        if (configurationValue == null && cluster != null) {
+            configurationValue = Assem2.getStringOrDft(graph, cluster, property, null, errorException);
+        }
+        if (configurationValue != null) {
+            configurationValue = checkForEnvironmentVariableValue(property.getURI(), configurationValue);
+        }
         return configurationValue;
     }
 

--- a/jena-kafka-connector/src/test/java/org/apache/jena/kafka/TestKafkaConnectorAssembler.java
+++ b/jena-kafka-connector/src/test/java/org/apache/jena/kafka/TestKafkaConnectorAssembler.java
@@ -21,6 +21,7 @@ import java.util.stream.Stream;
 public class TestKafkaConnectorAssembler {
 
     private static final String TEST_URI = "https://example.org/connector#1";
+    private static final String TEST_CLUSTER_URI = "https://example.org/cluster#1";
     private static final String TOPIC = "test";
     private static final String BOOTSTRAP_SERVERS = "localhost:9092";
     private static final String SERVICE_NAME = "/ds";
@@ -383,5 +384,153 @@ public class TestKafkaConnectorAssembler {
 
         // Then
         Assertions.assertEquals(expected, canonical);
+    }
+
+    private static void createConnectorWithoutBootstrap(Model config, Resource resource) {
+        config.add(resource, RDF.type, KafkaConnectorAssembler.tKafkaConnector);
+        config.add(resource, config.createProperty(KafkaConnectorAssembler.pKafkaTopic.getURI()),
+                   config.createLiteral(TOPIC));
+        config.add(resource, config.createProperty(KafkaConnectorAssembler.pFusekiServiceName.getURI()),
+                   config.createLiteral(SERVICE_NAME));
+        config.add(resource, config.createProperty(KafkaConnectorAssembler.pStateFile.getURI()),
+                   config.createLiteral(STATE_FILE));
+    }
+
+    private static Resource createCluster(Model config) {
+        Resource cluster = config.createResource(TEST_CLUSTER_URI);
+        config.add(cluster, RDF.type, KafkaConnectorAssembler.tKafkaCluster);
+        return cluster;
+    }
+
+    private static void addBootstrapServers(Model config, Resource resource, String value) {
+        config.add(resource, config.createProperty(KafkaConnectorAssembler.pKafkaBootstrapServers.getURI()),
+                   config.createLiteral(value));
+    }
+
+    private static void addConfigPair(Model config, Resource resource, String key, String value) {
+        config.add(resource, config.createProperty(KafkaConnectorAssembler.pKafkaProperty.getURI()),
+                   config.createList(config.createLiteral(key), config.createLiteral(value)));
+    }
+
+    private static void linkCluster(Model config, Resource connector, Resource cluster) {
+        config.add(connector, config.createProperty(KafkaConnectorAssembler.pCluster.getURI()), cluster);
+    }
+
+    @Test
+    public void givenConnectorReferencingCluster_whenAssembling_thenInheritsBootstrapAndConfig() {
+        // Given
+        Model config = ModelFactory.createDefaultModel();
+        Resource connector = config.createResource(TEST_URI);
+        createConnectorWithoutBootstrap(config, connector);
+        Resource cluster = createCluster(config);
+        addBootstrapServers(config, cluster, BOOTSTRAP_SERVERS);
+        addConfigPair(config, cluster, "max.poll.records", "100");
+        linkCluster(config, connector, cluster);
+
+        // When
+        Object assembled = assembler.open(connector);
+
+        // Then
+        Assertions.assertNotNull(assembled);
+        KConnectorDesc desc = (KConnectorDesc) assembled;
+        Assertions.assertEquals(BOOTSTRAP_SERVERS, desc.getBootstrapServers());
+        Assertions.assertEquals("100", desc.getKafkaConsumerProps().getProperty("max.poll.records"));
+    }
+
+    @Test
+    public void givenBootstrapOnConnectorAndCluster_whenAssembling_thenConnectorValueWins() {
+        // Given
+        Model config = ModelFactory.createDefaultModel();
+        Resource connector = config.createResource(TEST_URI);
+        createMinimalConfiguration(config, connector);
+        Resource cluster = createCluster(config);
+        addBootstrapServers(config, cluster, "cluster-host:9092");
+        linkCluster(config, connector, cluster);
+
+        // When
+        Object assembled = assembler.open(connector);
+
+        // Then
+        Assertions.assertNotNull(assembled);
+        Assertions.assertEquals(BOOTSTRAP_SERVERS, ((KConnectorDesc) assembled).getBootstrapServers());
+    }
+
+    @Test
+    public void givenConfigPropertyOnConnectorAndCluster_whenAssembling_thenConnectorValueWins() {
+        // Given
+        Model config = ModelFactory.createDefaultModel();
+        Resource connector = config.createResource(TEST_URI);
+        createMinimalConfiguration(config, connector);
+        addConfigPair(config, connector, "max.poll.records", "200");
+        Resource cluster = createCluster(config);
+        addConfigPair(config, cluster, "max.poll.records", "100");
+        linkCluster(config, connector, cluster);
+
+        // When
+        Object assembled = assembler.open(connector);
+
+        // Then
+        Assertions.assertNotNull(assembled);
+        Assertions.assertEquals("200", ((KConnectorDesc) assembled).getKafkaConsumerProps()
+                                                                   .getProperty("max.poll.records"));
+    }
+
+    @Test
+    public void givenClusterConfigFile_whenAssembling_thenInheritsFileProperties() throws IOException {
+        // Given
+        Model config = ModelFactory.createDefaultModel();
+        Resource connector = config.createResource(TEST_URI);
+        createConnectorWithoutBootstrap(config, connector);
+        Resource cluster = createCluster(config);
+        addBootstrapServers(config, cluster, BOOTSTRAP_SERVERS);
+        File propsFile = prepareExternalPropertiesFile(createTestProperties());
+        config.add(cluster, config.createProperty(KafkaConnectorAssembler.pKafkaPropertyFile.getURI()),
+                   config.createLiteral(propsFile.getAbsolutePath()));
+        linkCluster(config, connector, cluster);
+
+        // When
+        Object assembled = assembler.open(connector);
+
+        // Then
+        Assertions.assertNotNull(assembled);
+        verifyTestProperties((KConnectorDesc) assembled);
+    }
+
+    @Test
+    public void givenNoBootstrapOnConnectorOrCluster_whenAssembling_thenNotLoaded() {
+        // Given
+        Model config = ModelFactory.createDefaultModel();
+        Resource connector = config.createResource(TEST_URI);
+        createConnectorWithoutBootstrap(config, connector);
+        Resource cluster = createCluster(config);
+        linkCluster(config, connector, cluster);
+
+        // When
+        Object assembled = assembler.open(connector);
+
+        // Then
+        Assertions.assertNull(assembled);
+    }
+
+    @Test
+    public void givenGroupIdOnCluster_whenAssembling_thenNotInherited() {
+        // Given
+        Model config = ModelFactory.createDefaultModel();
+        Resource connector = config.createResource(TEST_URI);
+        createConnectorWithoutBootstrap(config, connector);
+        Resource cluster = createCluster(config);
+        addBootstrapServers(config, cluster, BOOTSTRAP_SERVERS);
+        config.add(cluster, config.createProperty(KafkaConnectorAssembler.pKafkaGroupId.getURI()),
+                   config.createLiteral("shared-group"));
+        linkCluster(config, connector, cluster);
+
+        // When
+        Object assembled = assembler.open(connector);
+
+        // Then
+        Assertions.assertNotNull(assembled);
+        // The group id is deliberately per-connector and must not be inherited from the cluster
+        Assertions.assertEquals(KafkaConnectorAssembler.DEFAULT_CONSUMER_GROUP_ID,
+                                ((KConnectorDesc) assembled).getConsumerGroupId());
     }
 }


### PR DESCRIPTION
Allow common Kafka config to be declared once on a shared fk:Cluster and reused across connectors.

Means we only have to define the bootstrap servers and config to the fk:cluster object that can be referenced by each Connecter.  Is backwards compatible. 