### PR TITLE
Use named Maven Central deployment and further reduce release size (CORE-1353)

### DIFF
--- a/jena-fmod-kafka/pom.xml
+++ b/jena-fmod-kafka/pom.xml
@@ -30,7 +30,11 @@
     <artifactId>jena-kafka</artifactId>
     <version>3.0.5-SNAPSHOT</version>
     <relativePath>..</relativePath>
-  </parent> 
+  </parent>
+
+  <properties>
+    <skipPublishing>true</skipPublishing>
+  </properties>
 
   <dependencies>
 

--- a/jena-fuseki-kafka-module/pom.xml
+++ b/jena-fuseki-kafka-module/pom.xml
@@ -73,6 +73,10 @@
           <groupId>commons-beanutils</groupId>
           <artifactId>commons-beanutils</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcprov-jdk18on</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/jena-kafka-connector/pom.xml
+++ b/jena-kafka-connector/pom.xml
@@ -204,6 +204,9 @@
                         <goals>
                             <goal>test-jar</goal>
                         </goals>
+                        <configuration>
+                            <skip>${skip.testJars}</skip>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -620,6 +620,7 @@
                     <publishingServerId>central</publishingServerId>
                     <autoPublish>true</autoPublish>
                     <waitUntil>validated</waitUntil>
+                    <deploymentName>Fuseki Kafka Connector ${project.version}</deploymentName>
                 </configuration>
             </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -603,6 +603,7 @@
                 <configuration>
                     <outputName>${project.artifactId}-${project.version}-bom</outputName>
                     <skipNotDeployed>false</skipNotDeployed>
+                    <outputFormat>json</outputFormat>
                 </configuration>
             </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,12 @@
         <project.build.outputTimestamp>2026-06-04T12:58:50Z</project.build.outputTimestamp>
         <coverage.minimum>0.8</coverage.minimum>
         <test.maxForks>2</test.maxForks>
+        <!--
+        Defaults to disabling test JARs
+
+        Can be set to false in individual modules if they need to publish test JARs for downstreamn consumers
+        -->
+        <skip.testJars>true</skip.testJars>
 
         <!-- Maven Plugin versions -->
         <plugin.central>0.11.0</plugin.central>
@@ -401,6 +407,7 @@
                             <goal>test-jar</goal>
                         </goals>
                         <configuration>
+                            <skip>${skip.testJars}</skip>
                             <classifier>tests</classifier>
                         </configuration>
                     </execution>
@@ -429,6 +436,9 @@
                         <goals>
                             <goal>test-jar-no-fork</goal>
                         </goals>
+                        <configuration>
+                            <skipSource>${skip.testJars}</skipSource>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -621,6 +631,7 @@
                     <autoPublish>true</autoPublish>
                     <waitUntil>validated</waitUntil>
                     <deploymentName>Fuseki Kafka Connector ${project.version}</deploymentName>
+                    <checksums>required</checksums>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
See telicent-oss/smart-caches-core#341 for context on the named deployment

Release size wise:

- Only publish minimum required checksums
- Don't produce `tests` and `test-sources` JARs except for modules that need to expose test code downstream
- Don't publish the fat JAR version of the Fuseki module since we don't use that ourselves outside local demo and development
- Only publish JSON format SBOMs