### PR TITLE
Log full stack trace when Projection fails (CORE-1453)

### DIFF
--- a/jena-fmod-kafka/pom.xml
+++ b/jena-fmod-kafka/pom.xml
@@ -34,6 +34,7 @@
 
   <properties>
     <skipPublishing>true</skipPublishing>
+    <sonar.skip>true</sonar.skip>
   </properties>
 
   <dependencies>

--- a/jena-fuseki-kafka-module/src/main/java/org/apache/jena/fuseki/kafka/FKS.java
+++ b/jena-fuseki-kafka-module/src/main/java/org/apache/jena/fuseki/kafka/FKS.java
@@ -140,7 +140,8 @@ public class FKS {
     private static void checkTopicsExistAtStartup(KConnectorDesc conn, String topicNames) {
         checkTopicsExistAtStartup(conn, topicNames, TOPIC_CHECK_TIMEOUT, TOPIC_CHECK_RETRY_MILLIS,
                                   props -> new TopicExistenceChecker(AdminClient.create(props),
-                                                                     conn.getBootstrapServers(), conn.getTopics(), LOG));
+                                                                     conn.getBootstrapServers(), conn.getTopics(),
+                                                                     LOG));
     }
 
     static void checkTopicsExistAtStartup(KConnectorDesc conn, String topicNames, Duration timeout,
@@ -173,8 +174,9 @@ public class FKS {
             }
             if (!allTopicsExist) {
                 throw new FusekiKafkaException(
-                        String.format("[%s] Strict startup checks are enabled but one/more configured topic(s) do not currently exist on Kafka server %s",
-                                      topicNames, conn.getBootstrapServers()));
+                        String.format(
+                                "[%s] Strict startup checks are enabled but one/more configured topic(s) do not currently exist on Kafka server %s",
+                                topicNames, conn.getBootstrapServers()));
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
@@ -367,8 +369,8 @@ public class FKS {
     }
 
     /**
-     * Requests that every Fuseki Projector attached to the given dataset pause at its
-     * next safe point (between events).
+     * Requests that every Fuseki Projector attached to the given dataset pause at its next safe point (between
+     * events).
      *
      * @param datasetName Dataset name
      */
@@ -377,8 +379,7 @@ public class FKS {
     }
 
     /**
-     * Releases a previously requested pause for every Fuseki Projector attached to the
-     * given dataset.
+     * Releases a previously requested pause for every Fuseki Projector attached to the given dataset.
      *
      * @param datasetName Dataset name
      */
@@ -387,8 +388,7 @@ public class FKS {
     }
 
     /**
-     * Blocks until every {@link FusekiProjector} attached to the given dataset has reached
-     * its pause point.
+     * Blocks until every {@link FusekiProjector} attached to the given dataset has reached its pause point.
      *
      * @param datasetName Dataset name
      * @param timeout     Maximum time to wait
@@ -423,8 +423,7 @@ public class FKS {
     }
 
     /**
-     * Iterates through the Projector Drivers registered for a dataset and applies the supplied
-     * action to each.
+     * Iterates through the Projector Drivers registered for a dataset and applies the supplied action to each.
      */
     private static void forEachFusekiProjector(String datasetName,
                                                java.util.function.Consumer<FusekiProjector> action) {
@@ -521,7 +520,11 @@ public class FKS {
                     } catch (ExecutionException e) {
                         // This means something fatal has happened on the polling thread to cause it to exit with an
                         // exception, log an error for this
-                        LOG.error("Polling thread failed: {}", e.getCause().getMessage());
+                        // NB - We intentionally log the error directly, and thus its full stack trace here.  As this is
+                        // an error on a ProjectorDriver thread and the ProjectorDriver will only log the basic error
+                        // message.  If we don't log the stack trace we have zero visibility into what the system was
+                        // doing when the error occurred making it difficult to debug.
+                        LOG.error("Polling thread failed: ", e.getCause());
                     } catch (InterruptedException | CancellationException e) {
                         // Ignore, we could be cancelled/interrupted for a legitimate reason like JVM shutdown so no
                         // point doing anything about those here.  If the poll thread continues to run then it'll check

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,9 @@
         -->
         <skip.testJars>true</skip.testJars>
 
+        <!-- SonarQube analysis, invoked from CI via mvn sonar:sonar -->
+        <sonar.projectKey>telicent-oss_jena-fuseki-kafka</sonar.projectKey>
+
         <!-- Maven Plugin versions -->
         <plugin.central>0.11.0</plugin.central>
         <plugin.clean>3.5.0</plugin.clean>
@@ -88,6 +91,7 @@
         <plugin.site>3.22.0</plugin.site>
         <plugin.source>3.4.0</plugin.source>
         <plugin.surefire>3.5.6</plugin.surefire>
+        <plugin.sonar>5.7.0.6970</plugin.sonar>
 
         <!-- Internal dependencies -->
         <dependency.jena>6.2.0</dependency.jena>
@@ -590,6 +594,12 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
                 <version>${plugin.site}</version>
+            </plugin>
+
+            <plugin>
+                <groupId>org.sonarsource.scanner.maven</groupId>
+                <artifactId>sonar-maven-plugin</artifactId>
+                <version>${plugin.sonar}</version>
             </plugin>
 
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
 
         <!-- Internal dependencies -->
         <dependency.jena>6.2.0</dependency.jena>
-        <dependency.smart-caches>1.1.0</dependency.smart-caches>
+        <dependency.smart-caches>1.2.0</dependency.smart-caches>
 
         <!-- External dependencies -->
         <dependency.commons-beanutils>1.11.0</dependency.commons-beanutils>


### PR DESCRIPTION
The `ProjectorDriver` only logs the message and the Fuseki Kafka monitoring thread only logged that again which doesn't aid debugging. Have the monitoring thread log the full stack trace which gives visibility into what the system was doing when the failure occurred.

Also bump SC-Core to latest release