### PR TITLE
Bugfix for detecting stall on quiet topic

### DIFF
--- a/jena-kafka-connector/src/main/java/org/apache/jena/kafka/common/FusekiProjector.java
+++ b/jena-kafka-connector/src/main/java/org/apache/jena/kafka/common/FusekiProjector.java
@@ -654,10 +654,19 @@ public class FusekiProjector implements StallAwareProjector<Event<Bytes, RdfPayl
             this.commit();
         }
 
-        // Stall is also the point at which a paused projector with no events flowing notices
-        // the pause request — without this, a quiet topic would leave the projector idle in
-        // the driver's poll loop and waitForPause() would have to wait for a poll timeout. The
-        // commit above ensures there is no in-flight transaction before we block.
+        // A pause may have been requested while events were still flowing, in which case this is
+        // the first opportunity to honour it. The commit above ensures there is no in-flight
+        // transaction before we block. Note that the driver only calls this on the FIRST of a run
+        // of consecutive stalls, so a projector that stalled some time ago observes a pause
+        // request via idle() instead.
+        awaitResumeIfPaused();
+    }
+
+    @Override
+    public void idle(Sink<Event<Bytes, RdfPayload>> sink) {
+        // Called by the driver on every poll that yields no events, so this is how a projector on
+        // a quiet topic notices a pause request. Deliberately cheap: awaitResumeIfPaused() returns
+        // immediately unless a pause has actually been requested.
         awaitResumeIfPaused();
     }
 
@@ -693,9 +702,13 @@ public class FusekiProjector implements StallAwareProjector<Event<Bytes, RdfPayl
     }
 
     /**
-     * Called by the projector thread on entry to {@link #project(Event, Sink)} and
-     * {@link #stalled(Sink)}. If a pause has been requested, commits any in-flight Jena
-     * transaction so the dataset is idle, then blocks until resumed.
+     * Called by the projector thread on entry to {@link #project(Event, Sink)},
+     * {@link #stalled(Sink)} and {@link #idle(Sink)}. If a pause has been requested, commits any
+     * in-flight Jena transaction so the dataset is idle, then blocks until resumed.
+     * <p>
+     * {@link #idle(Sink)} is what makes a pause reachable on a quiet topic: events may never
+     * arrive to trigger {@link #project(Event, Sink)}, and {@link #stalled(Sink)} is only called
+     * on the first of a run of consecutive stalls.
      */
     private void awaitResumeIfPaused() {
         if (!this.paused) return;

--- a/jena-kafka-connector/src/test/java/org/apache/jena/kafka/common/QuietEventSource.java
+++ b/jena-kafka-connector/src/test/java/org/apache/jena/kafka/common/QuietEventSource.java
@@ -1,0 +1,79 @@
+/*
+ *  Copyright (c) Telicent Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.jena.kafka.common;
+
+import io.telicent.smart.cache.payloads.RdfPayload;
+import io.telicent.smart.cache.sources.Event;
+import io.telicent.smart.cache.sources.EventSource;
+import org.apache.kafka.common.utils.Bytes;
+
+import java.time.Duration;
+import java.util.Collection;
+
+/**
+ * An event source that is caught up but not exhausted, i.e. every poll blocks for the timeout and then yields nothing.
+ * <p>
+ * This models a quiet Kafka topic, the state in which a projector is left stalled indefinitely in the driver's poll
+ * loop.
+ * </p>
+ */
+public class QuietEventSource implements EventSource<Bytes, RdfPayload> {
+
+    private volatile boolean closed = false;
+
+    @Override
+    public boolean availableImmediately() {
+        // Nothing is ever immediately available, so the driver expects poll() to block
+        return false;
+    }
+
+    @Override
+    public boolean isExhausted() {
+        // Caught up is not the same as exhausted, the topic may receive more events later
+        return this.closed;
+    }
+
+    @Override
+    public void close() {
+        this.closed = true;
+    }
+
+    @Override
+    public boolean isClosed() {
+        return this.closed;
+    }
+
+    @Override
+    public Event<Bytes, RdfPayload> poll(Duration timeout) {
+        try {
+            Thread.sleep(timeout.toMillis());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        return null;
+    }
+
+    @Override
+    public Long remaining() {
+        return 0L;
+    }
+
+    @Override
+    public void processed(Collection<Event<?, ?>> processedEvents) {
+        // No-op
+    }
+}

--- a/jena-kafka-connector/src/test/java/org/apache/jena/kafka/common/QuietEventSource.java
+++ b/jena-kafka-connector/src/test/java/org/apache/jena/kafka/common/QuietEventSource.java
@@ -23,6 +23,8 @@ import org.apache.kafka.common.utils.Bytes;
 
 import java.time.Duration;
 import java.util.Collection;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 /**
  * An event source that is caught up but not exhausted, i.e. every poll blocks for the timeout and then yields nothing.
@@ -34,6 +36,12 @@ import java.util.Collection;
 public class QuietEventSource implements EventSource<Bytes, RdfPayload> {
 
     private volatile boolean closed = false;
+
+    /**
+     * Released by {@link #close()} so that a blocked {@link #poll(Duration)} returns promptly instead of waiting out
+     * the remainder of its timeout.
+     */
+    private final CountDownLatch closeSignal = new CountDownLatch(1);
 
     @Override
     public boolean availableImmediately() {
@@ -50,6 +58,7 @@ public class QuietEventSource implements EventSource<Bytes, RdfPayload> {
     @Override
     public void close() {
         this.closed = true;
+        this.closeSignal.countDown();
     }
 
     @Override
@@ -60,7 +69,8 @@ public class QuietEventSource implements EventSource<Bytes, RdfPayload> {
     @Override
     public Event<Bytes, RdfPayload> poll(Duration timeout) {
         try {
-            Thread.sleep(timeout.toMillis());
+            // Blocks for the whole timeout unless the source is closed first, modelling a poll of a quiet topic
+            this.closeSignal.await(timeout.toMillis(), TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         }

--- a/jena-kafka-connector/src/test/java/org/apache/jena/kafka/common/TestFusekiProjectorReadiness.java
+++ b/jena-kafka-connector/src/test/java/org/apache/jena/kafka/common/TestFusekiProjectorReadiness.java
@@ -17,6 +17,7 @@
 package org.apache.jena.kafka.common;
 
 import io.telicent.smart.cache.payloads.RdfPayload;
+import io.telicent.smart.cache.projectors.driver.ProjectorDriver;
 import io.telicent.smart.cache.projectors.sinks.NullSink;
 import io.telicent.smart.cache.sources.Event;
 import io.telicent.smart.cache.sources.memory.InMemoryEventSource;
@@ -174,6 +175,85 @@ class TestFusekiProjectorReadiness extends AbstractFusekiProjectorTests {
         projector.requestResume();
         stalledCall.get(5, TimeUnit.SECONDS);
         Assertions.assertFalse(projector.isAtPausePoint());
+    }
+
+    @Test
+    @Timeout(10)
+    void givenPauseRequested_whenIdleCalled_thenItAlsoBlocksUntilResume() throws Exception {
+        // Given -- pause is requested. The projector is idle (no events flowing) and, crucially,
+        // stalled some time ago, so the driver will not call stalled() again. idle() is called on
+        // every poll that yields no events and is therefore the only path by which a long quiet
+        // projector can observe the pause request. Without it a restore would wait in vain.
+        final FusekiProjector projector = newProjectorWithEmptySource();
+        projector.requestPause();
+
+        // When -- simulate the driver calling idle() on the worker thread
+        final CompletableFuture<Void> idleCall = CompletableFuture.runAsync(() -> {
+            try (NullSink<Event<Bytes, RdfPayload>> sink = NullSink.of()) {
+                projector.idle(sink);
+            }
+        });
+
+        waitFor(projector::isAtPausePoint, Duration.ofSeconds(5),
+                "idle() did not reach pause point");
+        Assertions.assertFalse(idleCall.isDone(),
+                               "idle() should remain blocked while pause is in effect");
+
+        // Then -- resume releases idle()
+        projector.requestResume();
+        idleCall.get(5, TimeUnit.SECONDS);
+        Assertions.assertFalse(projector.isAtPausePoint());
+    }
+
+    @Test
+    @Timeout(10)
+    void givenNoPause_whenIdleCalled_thenReturnsImmediately() {
+        // Given -- no pause requested, i.e. the steady state for every poll of a quiet topic
+        final FusekiProjector projector = newProjectorWithEmptySource();
+
+        // When and Then -- idle() must not block, it is called on every poll
+        Assertions.assertTimeoutPreemptively(Duration.ofSeconds(5), () -> {
+            try (NullSink<Event<Bytes, RdfPayload>> sink = NullSink.of()) {
+                projector.idle(sink);
+            }
+        });
+        Assertions.assertFalse(projector.isAtPausePoint());
+    }
+
+    @Test
+    @Timeout(30)
+    void givenLongStalledDriver_whenPauseRequested_thenProjectorReachesPausePointWithoutAnyEvents() throws Exception {
+        // Given -- a real driver polling a quiet source with a real projector, i.e. the state a
+        // dataset is in when a restore is run on a caught up system. The driver only reports the
+        // first of a run of consecutive stalls, so by the time we request the pause below the
+        // stalled() notification is long gone and only idle() can deliver it.
+        final QuietEventSource source = new QuietEventSource();
+        final FusekiProjector projector =
+                buildProjector(createTestConnector(), source, mockDatasetGraph(), 100);
+        final ProjectorDriver<Bytes, RdfPayload, Event<Bytes, RdfPayload>> driver =
+                ProjectorDriver.<Bytes, RdfPayload, Event<Bytes, RdfPayload>>create()
+                               .source(source)
+                               .projector(projector)
+                               .destination(NullSink.of())
+                               .unlimited()
+                               .pollTimeout(Duration.ofMillis(200))
+                               .build();
+        final CompletableFuture<Void> driverRun = CompletableFuture.runAsync(driver);
+        waitFor(() -> driver.getConsecutiveStalls() >= 3, Duration.ofSeconds(10),
+                "Driver did not stall repeatedly");
+
+        try {
+            // When
+            projector.requestPause();
+
+            // Then -- this is what FKS.waitForPause() polls for on behalf of a restore
+            waitFor(projector::isAtPausePoint, Duration.ofSeconds(5),
+                    "Projector did not reach its pause point while stalled");
+        } finally {
+            projector.requestResume();
+            driver.cancel();
+            driverRun.get(10, TimeUnit.SECONDS);
+        }
     }
 
     // -----------------------------------------------------------------------------------

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
 
         <!-- Internal dependencies -->
         <dependency.jena>6.2.0</dependency.jena>
-        <dependency.smart-caches>1.2.1</dependency.smart-caches>
+        <dependency.smart-caches>1.2.2</dependency.smart-caches>
 
         <!-- External dependencies -->
         <dependency.commons-beanutils>1.11.0</dependency.commons-beanutils>


### PR DESCRIPTION
Adds implementaion of `idle(Sink)` (which was added to SC-Core in [PR #396](https://github.com/telicent-oss/smart-caches-core/pull/396)) to the `FusekiProjector`