### PR TITLE
Better handle projection errors and improved observability (CORE-1530)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Kafka Connector for Apache Jena Fuseki
 
-## 3.2.3
+## 3.3.0
 
 - Fixed a bug where `FusekiProjector` did not handle some recoverable error conditions by sending the event to the DLQ
+- `FKS` now exposes `launched()`, `failed()` and `running()` counts to provide better observability of how many polling 
+  threads have been launched and how many have failed
+    - Exposes the above counters as new OpenTelemetry metrics under the `fuseki.kafka.poll.threads.` prefix
 
 ## 3.2.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Kafka Connector for Apache Jena Fuseki
 
+## 3.2.3
+
+- Fixed a bug where `FusekiProjector` did not handle some recoverable error conditions by sending the event to the DLQ
+
 ## 3.2.2
 
 **NOTE** next version will need to be 3.2.2 as previous version was accidentally labelled as 3.2.1 during a failed

--- a/jena-fmod-kafka/pom.xml
+++ b/jena-fmod-kafka/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>io.telicent.jena</groupId>
     <artifactId>jena-kafka</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.3.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>io.telicent.jena</groupId>
       <artifactId>jena-fuseki-kafka-module</artifactId>
-      <version>3.2.1-SNAPSHOT</version>
+      <version>3.3.0-SNAPSHOT</version>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>

--- a/jena-fuseki-kafka-module/pom.xml
+++ b/jena-fuseki-kafka-module/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>io.telicent.jena</groupId>
     <artifactId>jena-kafka</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.3.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/jena-fuseki-kafka-module/src/main/java/org/apache/jena/fuseki/kafka/FKS.java
+++ b/jena-fuseki-kafka-module/src/main/java/org/apache/jena/fuseki/kafka/FKS.java
@@ -16,6 +16,8 @@
 
 package org.apache.jena.fuseki.kafka;
 
+import io.opentelemetry.api.metrics.Meter;
+import io.telicent.smart.cache.observability.TelicentMetrics;
 import io.telicent.smart.cache.payloads.RdfPayload;
 import io.telicent.smart.cache.projectors.Sink;
 import io.telicent.smart.cache.projectors.driver.ProjectorDriver;
@@ -37,6 +39,7 @@ import org.apache.jena.fuseki.server.DataAccessPointRegistry;
 import org.apache.jena.fuseki.server.DataService;
 import org.apache.jena.kafka.JenaKafkaException;
 import org.apache.jena.kafka.KConnectorDesc;
+import org.apache.jena.kafka.SysJenaKafka;
 import org.apache.jena.kafka.common.FusekiOffsetStore;
 import org.apache.jena.kafka.common.FusekiProjector;
 import org.apache.jena.kafka.common.FusekiSink;
@@ -51,6 +54,7 @@ import org.apache.kafka.common.utils.Bytes;
 import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
 import static org.apache.jena.kafka.FusekiKafka.LOG;
@@ -59,6 +63,7 @@ import static org.apache.jena.kafka.FusekiKafka.LOG;
  * Functions for Fuseki-Kafka server setup.
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
+@SuppressWarnings("resource")
 public class FKS {
 
     /**
@@ -188,7 +193,7 @@ public class FKS {
             Thread.currentThread().interrupt();
             throw new JenaKafkaException(
                     String.format("[%s] Interrupted while performing strict startup topic checks", topicNames), e);
-        } catch (JenaKafkaException e){
+        } catch (JenaKafkaException e) {
             throw e;
         } catch (RuntimeException e) {
             throw new JenaKafkaException(
@@ -260,6 +265,68 @@ public class FKS {
     private static final List<Future<?>> ACTIVE_DRIVERS = new CopyOnWriteArrayList<>();
     private static PollThreadMonitor MONITOR;
     private static ExecutorService EXECUTOR = threadExecutor();
+    private static final AtomicInteger LAUNCHED = new AtomicInteger(0);
+    private static final AtomicInteger FAILED = new AtomicInteger(0);
+
+    /**
+     * Prefix to the metric names used to report the {@link #launched()}, {@link #failed()} and {@link #running()}
+     * metrics to OpenTelemetry
+     */
+    public static final String OTEL_POLL_THREADS_METRIC_PREFIX = "fuseki.kafka.poll.threads.";
+
+    static {
+        Meter meter = TelicentMetrics.getMeter("fuseki-kafka", SysJenaKafka.VERSION);
+        meter.gaugeBuilder(OTEL_POLL_THREADS_METRIC_PREFIX + "launched")
+             .ofLongs()
+             .setDescription("Number of Kafka polling threads that have been launched")
+             .buildWithCallback(measurement -> measurement.record(FKS.launched()));
+        meter.gaugeBuilder(OTEL_POLL_THREADS_METRIC_PREFIX + "failed")
+             .ofLongs()
+             .setDescription("Number of Kafka polling threads that have failed")
+             .buildWithCallback(measurement -> measurement.record(FKS.failed()));
+        meter.gaugeBuilder(OTEL_POLL_THREADS_METRIC_PREFIX + "running")
+             .ofLongs()
+             .setDescription("Number of Kafka polling threads that are actively running")
+             .buildWithCallback(measurement -> measurement.record(FKS.running()));
+    }
+
+    /**
+     * Gets how many, if any, polling threads have been launched
+     * <p>
+     * By comparing this and {@link #failed()} a caller can determine both whether any Fuseki Kafka processing is
+     * running and whether it is healthy.
+     * </p>
+     *
+     * @return Number of launched polling threads
+     */
+    public static int launched() {
+        return LAUNCHED.get();
+    }
+
+    /**
+     * Gets how many, if any, polling threads have failed
+     *
+     * @return Number of failed polling threads
+     */
+    public static int failed() {
+        return FAILED.get();
+    }
+
+    /**
+     * Gets how many actively running polling threads exist
+     * <p>
+     * Note that this may not return the same value as calculating it from <code>launched() - failed()</code> as this
+     * only reports actively running threads and a failure may not have been spotted by the monitoring thread and used
+     * to update those counts yet.  Also, if the service was in the process of shutting down then the threads may have
+     * been cancelled and/or naturally completed and that is not considered a failure so a naive calculation would
+     * return a higher number of active threads than there actually are.
+     * </p>
+     *
+     * @return Actively running threads
+     */
+    public static int running() {
+        return ACTIVE_DRIVERS.stream().filter(f -> !f.isDone()).mapToInt(i -> 1).sum();
+    }
 
     private static ExecutorService threadExecutor() {
         ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor();
@@ -273,7 +340,12 @@ public class FKS {
 
 
     /**
-     * The background threads
+     * Resets all polling threads and associated thread execution machinery, explicitly cancelling threads wherever
+     * possible.
+     * <p>
+     * Intended primarily for use within unit and integration tests to allow resetting the Fuseki Kafka machinery
+     * between tests.
+     * </p>
      */
     static void resetPollThreads() {
         // Explicitly cancel the projector drivers
@@ -296,12 +368,14 @@ public class FKS {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         }
+        LAUNCHED.set(0);
+        FAILED.set(0);
         EXECUTOR = threadExecutor();
     }
 
-    private static void startTopicPoll(KConnectorDesc connector, KafkaRdfPayloadSource<Bytes> source,
-                                       DatasetGraph destination,
-                                       Function<DatasetGraph, Sink<Event<Bytes, RdfPayload>>> sinkBuilder) {
+    static void startTopicPoll(KConnectorDesc connector, KafkaRdfPayloadSource<Bytes> source,
+                               DatasetGraph destination,
+                               Function<DatasetGraph, Sink<Event<Bytes, RdfPayload>>> sinkBuilder) {
 
         //@formatter:off
         Sink<Event<Bytes, RdfPayload>> dlq = null;
@@ -339,6 +413,7 @@ public class FKS {
 
         // Submit for execution, and register for cancellation
         Future<?> future = EXECUTOR.submit(driver);
+        LAUNCHED.incrementAndGet();
         DRIVERS.computeIfAbsent(connector.getDatasetName(), x -> new CopyOnWriteArrayList<>()).add(driver);
 
         // Wait briefly for the projector driver thread to spin up
@@ -348,10 +423,12 @@ public class FKS {
             Thread.currentThread().interrupt();
             future.cancel(true);
             DRIVERS.getOrDefault(connector.getDatasetName(), Collections.emptyList()).remove(driver);
+            FAILED.incrementAndGet();
             throw new JenaKafkaException("Interrupted while waiting for connector to start up", e);
         } catch (ExecutionException e) {
             // If the projector driver fails in the startup phase we should bail out immediately
             DRIVERS.getOrDefault(connector.getDatasetName(), Collections.emptyList()).remove(driver);
+            FAILED.incrementAndGet();
             throw new JenaKafkaException("Connector failed to start up", e);
         } catch (TimeoutException e) {
             // Ignore, we can safely assume the projector driver thread started up cleanly
@@ -561,6 +638,7 @@ public class FKS {
                 // message.  If we don't log the stack trace we have zero visibility into what the system was
                 // doing when the error occurred making it difficult to debug.
                 LOG.error("Polling thread failed: ", e.getCause());
+                FAILED.incrementAndGet();
             } catch (InterruptedException e) {
                 stopAfterInterrupt();
             } catch (CancellationException | TimeoutException e) {

--- a/jena-fuseki-kafka-module/src/test/java/org/apache/jena/fuseki/kafka/TestFKS.java
+++ b/jena-fuseki-kafka-module/src/test/java/org/apache/jena/fuseki/kafka/TestFKS.java
@@ -1,11 +1,14 @@
 package org.apache.jena.fuseki.kafka;
 
 import io.telicent.smart.cache.payloads.RdfPayload;
+import io.telicent.smart.cache.projectors.Sink;
 import io.telicent.smart.cache.projectors.driver.ProjectorDriver;
 import io.telicent.smart.cache.projectors.sinks.NullSink;
 import io.telicent.smart.cache.sources.Event;
 import io.telicent.smart.cache.sources.kafka.KafkaEventSource;
+import io.telicent.smart.cache.sources.kafka.KafkaRdfPayloadSource;
 import io.telicent.smart.cache.sources.kafka.TopicExistenceChecker;
+import io.telicent.smart.cache.sources.memory.SimpleEvent;
 import org.apache.jena.fuseki.main.FusekiServer;
 import org.apache.jena.fuseki.server.DataAccessPoint;
 import org.apache.jena.fuseki.server.DataAccessPointRegistry;
@@ -38,9 +41,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.Mockito.*;
 
+@SuppressWarnings("resource")
 public class TestFKS {
-
-    private ExecutorService originalExecutor;
 
     static {
         JenaSystem.init();
@@ -50,12 +52,7 @@ public class TestFKS {
     @AfterMethod
     public void cleanup() {
         FKRegistry.get().reset();
-        drivers().clear();
-        activeDrivers().clear();
-        if (this.originalExecutor != null) {
-            setExecutor(this.originalExecutor);
-            this.originalExecutor = null;
-        }
+        FKS.resetPollThreads();
     }
 
     @Test(dataProvider = "paths")
@@ -87,10 +84,7 @@ public class TestFKS {
     @DataProvider(name = "paths")
     private Object[][] paths() {
         return new Object[][] {
-                { "/ds" },
-                { "/ds/" },
-                { "/ds/upload" },
-                { "/ds/upload/"}
+                { "/ds" }, { "/ds/" }, { "/ds/upload" }, { "/ds/upload/" }
         };
     }
 
@@ -98,7 +92,7 @@ public class TestFKS {
     public void givenNonEmptyDapRegistry_whenFindingDataset_thenFound(String path) {
         // Given
         DatasetGraph dsg = DatasetGraphFactory.empty();
-        DataAccessPointRegistry registry = new  DataAccessPointRegistry();
+        DataAccessPointRegistry registry = new DataAccessPointRegistry();
         DataService service = mock(DataService.class);
         when(service.getDataset()).thenReturn(dsg);
         registry.register(new DataAccessPoint("ds", service));
@@ -122,11 +116,11 @@ public class TestFKS {
     public void givenRegisteredConnectors_whenFindingTopics_thenMatchingTopicsReturned() {
         // Given
         KConnectorDesc dsConnector =
-                new KConnectorDesc(List.of("topic-a"), "localhost:9092", "/ds", "target/test.state",
-                                   false, false, false, null, new Properties());
+                new KConnectorDesc(List.of("topic-a"), "localhost:9092", "/ds", "target/test.state", false, false,
+                                   false, null, new Properties());
         KConnectorDesc nestedConnector =
-                new KConnectorDesc(List.of("topic-b"), "localhost:9092", "/ds/upload", "target/test.state",
-                                   false, false, false, null, new Properties());
+                new KConnectorDesc(List.of("topic-b"), "localhost:9092", "/ds/upload", "target/test.state", false,
+                                   false, false, null, new Properties());
         FKRegistry.get().register(dsConnector.getTopics(), dsConnector);
         FKRegistry.get().register(nestedConnector.getTopics(), nestedConnector);
 
@@ -141,8 +135,8 @@ public class TestFKS {
     public void givenStartupTopicChecksDisabled_whenCheckingTopics_thenNoCheckerCreated() {
         // Given
         KConnectorDesc conn =
-                new KConnectorDesc(List.of("topic-a"), "localhost:9092", "/ds", "target/test.state",
-                                   false, false, false, null, new Properties());
+                new KConnectorDesc(List.of("topic-a"), "localhost:9092", "/ds", "target/test.state", false, false,
+                                   false, null, new Properties());
         AtomicBoolean checkerCreated = new AtomicBoolean(false);
 
         // When
@@ -159,8 +153,8 @@ public class TestFKS {
     public void givenTopicChecksEnabledAndTopicsExist_whenCheckingTopics_thenSucceeds() {
         // Given
         KConnectorDesc conn =
-                new KConnectorDesc(List.of("topic-a"), "localhost:9092", "/ds", "target/test.state",
-                                   false, false, true, null, new Properties());
+                new KConnectorDesc(List.of("topic-a"), "localhost:9092", "/ds", "target/test.state", false, false, true,
+                                   null, new Properties());
 
         // When/Then
         FKS.checkTopicsExistAtStartup(conn, "topic-a", Duration.ofMillis(10), 1,
@@ -172,16 +166,18 @@ public class TestFKS {
     public void givenTopicChecksEnabledAndTopicsMissing_whenCheckingTopics_thenFails() {
         // Given
         KConnectorDesc conn =
-                new KConnectorDesc(List.of("topic-a"), "localhost:9092", "/ds", "target/test.state",
-                                   false, false, true, null, new Properties());
+                new KConnectorDesc(List.of("topic-a"), "localhost:9092", "/ds", "target/test.state", false, false, true,
+                                   null, new Properties());
         AdminClient adminClient = mock(AdminClient.class);
         when(adminClient.describeTopics(anyCollection())).thenThrow(new UnknownTopicOrPartitionException("missing"));
         Function<Properties, TopicExistenceChecker> checkerFactory =
                 props -> new TopicExistenceChecker(adminClient, conn.getBootstrapServers(), conn.getTopics(), null);
 
         // When/Then
-        JenaKafkaException ex = Assert.expectThrows(JenaKafkaException.class, () -> FKS.checkTopicsExistAtStartup(
-                conn, "topic-a", Duration.ofMillis(10), 1, checkerFactory));
+        JenaKafkaException ex = Assert.expectThrows(JenaKafkaException.class,
+                                                    () -> FKS.checkTopicsExistAtStartup(conn, "topic-a",
+                                                                                        Duration.ofMillis(10), 1,
+                                                                                        checkerFactory));
         Assert.assertTrue(ex.getMessage().contains("Strict startup checks are enabled"));
     }
 
@@ -189,14 +185,17 @@ public class TestFKS {
     public void givenTopicChecksEnabledAndCheckerCreationFailsWithRuntime_whenCheckingTopics_thenRuntimeWrapped() {
         // Given
         KConnectorDesc conn =
-                new KConnectorDesc(List.of("topic-a"), "localhost:9092", "/ds", "target/test.state",
-                                   false, false, true, null, new Properties());
+                new KConnectorDesc(List.of("topic-a"), "localhost:9092", "/ds", "target/test.state", false, false, true,
+                                   null, new Properties());
 
         // When/Then
-        JenaKafkaException ex = Assert.expectThrows(JenaKafkaException.class, () -> FKS.checkTopicsExistAtStartup(
-                conn, "topic-a", Duration.ofMillis(10), 1, props -> {
-                    throw new RuntimeException("boom");
-                }));
+        JenaKafkaException ex = Assert.expectThrows(JenaKafkaException.class,
+                                                    () -> FKS.checkTopicsExistAtStartup(conn, "topic-a",
+                                                                                        Duration.ofMillis(10), 1,
+                                                                                        props -> {
+                                                                                            throw new RuntimeException(
+                                                                                                    "boom");
+                                                                                        }));
         Assert.assertTrue(ex.getMessage().contains("Failed while performing strict startup topic checks"));
     }
 
@@ -204,14 +203,17 @@ public class TestFKS {
     public void givenTopicChecksEnabledAndCheckerCreationFailsWithFusekiException_whenCheckingTopics_thenOriginalExceptionPropagated() {
         // Given
         KConnectorDesc conn =
-                new KConnectorDesc(List.of("topic-a"), "localhost:9092", "/ds", "target/test.state",
-                                   false, false, true, null, new Properties());
+                new KConnectorDesc(List.of("topic-a"), "localhost:9092", "/ds", "target/test.state", false, false, true,
+                                   null, new Properties());
 
         // When/Then
-        JenaKafkaException ex = Assert.expectThrows(JenaKafkaException.class, () -> FKS.checkTopicsExistAtStartup(
-                conn, "topic-a", Duration.ofMillis(10), 1, props -> {
-                    throw new JenaKafkaException("pre-existing failure");
-                }));
+        JenaKafkaException ex = Assert.expectThrows(JenaKafkaException.class,
+                                                    () -> FKS.checkTopicsExistAtStartup(conn, "topic-a",
+                                                                                        Duration.ofMillis(10), 1,
+                                                                                        props -> {
+                                                                                            throw new JenaKafkaException(
+                                                                                                    "pre-existing failure");
+                                                                                        }));
         Assert.assertEquals(ex.getMessage(), "pre-existing failure");
     }
 
@@ -219,16 +221,17 @@ public class TestFKS {
     public void givenTopicChecksEnabled_whenCheckingTopics_thenCheckerIsClosed() {
         // Given
         KConnectorDesc conn =
-                new KConnectorDesc(List.of("topic-a"), "localhost:9092", "/ds", "target/test.state",
-                                   false, false, true, null, new Properties());
+                new KConnectorDesc(List.of("topic-a"), "localhost:9092", "/ds", "target/test.state", false, false, true,
+                                   null, new Properties());
         AdminClient adminClient = mock(AdminClient.class);
         when(adminClient.describeTopics(anyCollection())).thenThrow(new UnknownTopicOrPartitionException("missing"));
-        TopicExistenceChecker checker = new TopicExistenceChecker(adminClient, conn.getBootstrapServers(),
-                                                                  conn.getTopics(), null);
+        TopicExistenceChecker checker =
+                new TopicExistenceChecker(adminClient, conn.getBootstrapServers(), conn.getTopics(), null);
 
         // When
-        Assert.expectThrows(JenaKafkaException.class, () -> FKS.checkTopicsExistAtStartup(
-                conn, "topic-a", Duration.ofMillis(10), 1, props -> checker));
+        Assert.expectThrows(JenaKafkaException.class,
+                            () -> FKS.checkTopicsExistAtStartup(conn, "topic-a", Duration.ofMillis(10), 1,
+                                                                props -> checker));
 
         // Then
         verify(adminClient, times(1)).close();
@@ -244,7 +247,8 @@ public class TestFKS {
 
         // When/Then
         JenaKafkaException ex = Assert.expectThrows(JenaKafkaException.class,
-                                                      () -> FKS.addConnectorToServer(conn, server, offsets, dsg -> NullSink.of()));
+                                                    () -> FKS.addConnectorToServer(conn, server, offsets,
+                                                                                   dsg -> NullSink.of()));
         Assert.assertTrue(ex.getMessage().contains("No dataset found"));
     }
 
@@ -273,9 +277,12 @@ public class TestFKS {
 
         // When/Then
         try {
-            JenaKafkaException ex = Assert.expectThrows(JenaKafkaException.class,
-                                                          () -> FKS.addConnectorToServer(conn, serverForDataset("/ds", DatasetGraphFactory.empty()),
-                                                                                         offsets, dsg -> NullSink.of()));
+            JenaKafkaException ex = Assert.expectThrows(JenaKafkaException.class, () -> FKS.addConnectorToServer(conn,
+                                                                                                                 serverForDataset(
+                                                                                                                         "/ds",
+                                                                                                                         DatasetGraphFactory.empty()),
+                                                                                                                 offsets,
+                                                                                                                 dsg -> NullSink.of()));
             Assert.assertTrue(ex.getMessage().contains("Interrupted while waiting for connector to start up"));
             Assert.assertTrue(Thread.currentThread().isInterrupted());
             Assert.assertTrue(drivers().getOrDefault("/ds", Collections.emptyList()).isEmpty());
@@ -292,9 +299,12 @@ public class TestFKS {
         FusekiOffsetStore offsets = FusekiOffsetStore.builder().datasetName("/ds").build();
 
         // When/Then
-        JenaKafkaException ex = Assert.expectThrows(JenaKafkaException.class,
-                                                      () -> FKS.addConnectorToServer(conn, serverForDataset("/ds", DatasetGraphFactory.empty()),
-                                                                                     offsets, dsg -> NullSink.of()));
+        JenaKafkaException ex = Assert.expectThrows(JenaKafkaException.class, () -> FKS.addConnectorToServer(conn,
+                                                                                                             serverForDataset(
+                                                                                                                     "/ds",
+                                                                                                                     DatasetGraphFactory.empty()),
+                                                                                                             offsets,
+                                                                                                             dsg -> NullSink.of()));
         Assert.assertTrue(ex.getMessage().contains("Connector failed to start up"));
         Assert.assertTrue(drivers().getOrDefault("/ds", Collections.emptyList()).isEmpty());
     }
@@ -307,8 +317,8 @@ public class TestFKS {
         offsets.saveOffset("topica-0-group-2", 8L);
         offsets.saveOffset("topicb-1-group-1", 5L);
         KafkaEventSource<Bytes, RdfPayload> kafkaSource = mock(KafkaEventSource.class);
-        @SuppressWarnings("unchecked")
-        ProjectorDriver<Bytes, RdfPayload, Event<Bytes, RdfPayload>> driver = mock(ProjectorDriver.class);
+        @SuppressWarnings("unchecked") ProjectorDriver<Bytes, RdfPayload, Event<Bytes, RdfPayload>> driver =
+                mock(ProjectorDriver.class);
         when(driver.getSource()).thenReturn(kafkaSource);
         drivers().put("/ds", new ArrayList<>(List.of(driver)));
 
@@ -316,8 +326,8 @@ public class TestFKS {
         FKS.restoreOffsetForDataset("/ds", offsets);
 
         // Then
-        verify(kafkaSource, times(1)).resetOffsets(Map.of(new TopicPartition("topica", 0), 8L,
-                                                          new TopicPartition("topicb", 1), 5L));
+        verify(kafkaSource, times(1)).resetOffsets(
+                Map.of(new TopicPartition("topica", 0), 8L, new TopicPartition("topicb", 1), 5L));
     }
 
     @Test
@@ -329,11 +339,59 @@ public class TestFKS {
         FKS.restoreOffsetForDataset("/unknown", offsets);
     }
 
+    @Test
+    @SuppressWarnings("unchecked")
+    public void givenFailingSink_whenRunningProjector_thenFailedProjectionsReported() {
+        // Given
+        KConnectorDesc conn =
+                new KConnectorDesc(List.of("topica"), "localhost:9092", "/ds", "target/test.state", false, false, false,
+                                   null, null);
+        KafkaRdfPayloadSource<Bytes> kafkaSource = mock(KafkaRdfPayloadSource.class);
+        when(kafkaSource.poll(any())).thenReturn(
+                new SimpleEvent<>(Collections.emptyList(), null, RdfPayload.of(DatasetGraphFactory.empty())));
+        DatasetGraph dsg = mock(DatasetGraph.class);
+        Function<DatasetGraph, Sink<Event<Bytes, RdfPayload>>> sinkBuilder =
+                data -> event -> {throw new IllegalStateException("fails");};
+
+        // When
+        Assert.assertThrows(JenaKafkaException.class, () -> FKS.startTopicPoll(conn, kafkaSource, dsg, sinkBuilder));
+
+        // Then
+        Assert.assertEquals(FKS.launched(), 1, "Should have reported driver as launched");
+        Assert.assertEquals(FKS.failed(), 1, "Should have reported driver as failing");
+        Assert.assertEquals(FKS.running(), 0, "Should have reported no drivers as running");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void givenSomeFailingSinks_whenRunningMultipleProjectors_thenFailedProjectionsReported() {
+        // Given
+        KConnectorDesc conn =
+                new KConnectorDesc(List.of("topica"), "localhost:9092", "/ds", "target/test.state", false, false, false,
+                                   null, null);
+        KafkaRdfPayloadSource<Bytes> kafkaSource = mock(KafkaRdfPayloadSource.class);
+        when(kafkaSource.poll(any())).thenReturn(
+                new SimpleEvent<>(Collections.emptyList(), null, RdfPayload.of(DatasetGraphFactory.empty())));
+        DatasetGraph dsg = mock(DatasetGraph.class);
+        Function<DatasetGraph, Sink<Event<Bytes, RdfPayload>>> goodSinkBuilder = data -> NullSink.of();
+        Function<DatasetGraph, Sink<Event<Bytes, RdfPayload>>> badSinkBuilder =
+                data -> event -> {throw new IllegalStateException("fails");};
+
+        // When
+        FKS.startTopicPoll(conn, kafkaSource, dsg, goodSinkBuilder);
+        Assert.assertThrows(JenaKafkaException.class, () -> FKS.startTopicPoll(conn, kafkaSource, dsg, badSinkBuilder));
+
+        // Then
+        Assert.assertEquals(FKS.launched(), 2, "Should have reported both drivers as launched");
+        Assert.assertEquals(FKS.failed(), 1, "Should have reported one driver as failing");
+        Assert.assertEquals(FKS.running(), 1, "Should have reported one driver as running");
+    }
+
     private static KConnectorDesc connector(String datasetName) {
         Properties properties = new Properties();
         properties.put(ConsumerConfig.GROUP_ID_CONFIG, "test-group");
-        return new KConnectorDesc(List.of("topica"), "localhost:9092", datasetName, "target/test.state",
-                                  false, false, false, "topica-dlq", properties);
+        return new KConnectorDesc(List.of("topica"), "localhost:9092", datasetName, "target/test.state", false, false,
+                                  false, "topica-dlq", properties);
     }
 
     private static FusekiServer serverForDataset(String datasetPath, DatasetGraph dataset) {
@@ -348,7 +406,8 @@ public class TestFKS {
 
     @SuppressWarnings("unchecked")
     private static Map<String, List<ProjectorDriver<Bytes, RdfPayload, Event<Bytes, RdfPayload>>>> drivers() {
-        return (Map<String, List<ProjectorDriver<Bytes, RdfPayload, Event<Bytes, RdfPayload>>>>) getStaticField("DRIVERS");
+        return (Map<String, List<ProjectorDriver<Bytes, RdfPayload, Event<Bytes, RdfPayload>>>>) getStaticField(
+                "DRIVERS");
     }
 
     @SuppressWarnings("unchecked")
@@ -357,7 +416,6 @@ public class TestFKS {
     }
 
     private RecordingExecutor replaceExecutor(FakeFuture future) {
-        this.originalExecutor = (ExecutorService) getStaticField("EXECUTOR");
         RecordingExecutor executor = new RecordingExecutor(future);
         setExecutor(executor);
         return executor;
@@ -384,9 +442,7 @@ public class TestFKS {
     }
 
     private enum FakeFutureMode {
-        TIMEOUT,
-        EXECUTION,
-        INTERRUPTED
+        TIMEOUT, EXECUTION, INTERRUPTED
     }
 
     private static final class FakeFuture implements Future<Object> {
@@ -419,7 +475,8 @@ public class TestFKS {
         }
 
         @Override
-        public Object get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+        public Object get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException,
+                TimeoutException {
             switch (this.mode) {
                 case TIMEOUT:
                     throw new TimeoutException("still running");

--- a/jena-kafka-connector/pom.xml
+++ b/jena-kafka-connector/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>io.telicent.jena</groupId>
         <artifactId>jena-kafka</artifactId>
-        <version>3.2.1-SNAPSHOT</version>
+        <version>3.3.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/jena-kafka-connector/src/main/java/org/apache/jena/kafka/common/FusekiProjector.java
+++ b/jena-kafka-connector/src/main/java/org/apache/jena/kafka/common/FusekiProjector.java
@@ -164,16 +164,14 @@ public class FusekiProjector implements StallAwareProjector<Event<Bytes, RdfPayl
     private boolean highLagDetected = false;
 
     /**
-     * Pause coordination — see {@link #requestPause()} / {@link #requestResume()} /
-     * {@link #awaitResumeIfPaused()}.
+     * Pause coordination — see {@link #requestPause()} / {@link #requestResume()} / {@link #awaitResumeIfPaused()}.
      * <p>
-     * {@code paused} is the request flag (set from another thread, e.g. the SCG restore
-     * handler). {@code atPausePoint} reports whether the projector thread has actually
-     * reached the pause point and is currently blocked — used by {@link FusekiProjector} to
-     * tell {@code FKS.waitForPause(...)} when it is safe to begin a restore.
+     * {@code paused} is the request flag (set from another thread, e.g. the SCG restore handler). {@code atPausePoint}
+     * reports whether the projector thread has actually reached the pause point and is currently blocked — used by
+     * {@link FusekiProjector} to tell {@code FKS.waitForPause(...)} when it is safe to begin a restore.
      * <p>
-     * Both are read without locking; {@code pauseMonitor} guards the wait/notify of the
-     * projector thread while it is blocked.
+     * Both are read without locking; {@code pauseMonitor} guards the wait/notify of the projector thread while it is
+     * blocked.
      */
     private final Object pauseMonitor = new Object();
     private volatile boolean paused = false;
@@ -280,6 +278,14 @@ public class FusekiProjector implements StallAwareProjector<Event<Bytes, RdfPayl
             if (!sendToDlq(event, e)) {
                 throw new JenaKafkaException("Malformed Kafka event", e);
             }
+        } catch (Exception e) {
+            // Any other exception unclear what went wrong/when it went wrong, try to send to the DLQ then abort and
+            // replay for safety
+            if (!sendToDlq(event, e)) {
+                abort();
+                throw e;
+            }
+            abortAndReplay(sink);
         }
     }
 
@@ -297,13 +303,15 @@ public class FusekiProjector implements StallAwareProjector<Event<Bytes, RdfPayl
         // Log the error
         if (event instanceof KafkaEvent<Bytes, RdfPayload> kafkaEvent) {
             ConsumerRecord<Bytes, RdfPayload> consumerRecord = kafkaEvent.getConsumerRecord();
-            FusekiKafka.LOG.error("[{}] Partition {} Offset {}: {} [exceptionClass={}, rootCauseClass={}, rootCauseMessage={}]",
-                                  consumerRecord.topic(), consumerRecord.partition(), consumerRecord.offset(), reason,
-                                  e.getClass().getName(), rootCause.getClass().getName(), rootCause.getMessage(), e);
+            FusekiKafka.LOG.error(
+                    "[{}] Partition {} Offset {}: {} [exceptionClass={}, rootCauseClass={}, rootCauseMessage={}]",
+                    consumerRecord.topic(), consumerRecord.partition(), consumerRecord.offset(), reason,
+                    e.getClass().getName(), rootCause.getClass().getName(), rootCause.getMessage(), e);
         } else {
-            FusekiKafka.LOG.error("[{}] Malformed Event: {} [reason={}, exceptionClass={}, rootCauseClass={}, rootCauseMessage={}]",
-                                  topicNames, event, reason, e.getClass().getName(), rootCause.getClass().getName(),
-                                  rootCause.getMessage(), e);
+            FusekiKafka.LOG.error(
+                    "[{}] Malformed Event: {} [reason={}, exceptionClass={}, rootCauseClass={}, rootCauseMessage={}]",
+                    topicNames, event, reason, e.getClass().getName(), rootCause.getClass().getName(),
+                    rootCause.getMessage(), e);
         }
 
         // Try to send to DLQ if configured
@@ -347,8 +355,8 @@ public class FusekiProjector implements StallAwareProjector<Event<Bytes, RdfPayl
 
         String rootCauseMessage = rootCause.getMessage();
         return reason.contains(rootCause.getClass().getSimpleName()) ||
-               reason.contains(rootCause.getClass().getName()) ||
-               StringUtils.isNotBlank(rootCauseMessage) && reason.contains(rootCauseMessage);
+                reason.contains(rootCause.getClass().getName()) ||
+                StringUtils.isNotBlank(rootCauseMessage) && reason.contains(rootCauseMessage);
     }
 
     private static String rootCauseMessage(Throwable rootCause) {
@@ -361,6 +369,11 @@ public class FusekiProjector implements StallAwareProjector<Event<Bytes, RdfPayl
      * This is called when processing fails during application of an event since we can't guarantee that the event was
      * applied cleanly.  Thus, we need to abort the whole transaction and then replay the prior uncommitted events that
      * did apply cleanly to ensure we don't lose any data.
+     * </p>
+     * <p>
+     * If the processing failed due to some non-recoverable error in the target sink this method does no error handling
+     * so the fatal error would bubble upwards back into {@link #project(Event, Sink)} and be thrown upwards causing the
+     * projection to abort.
      * </p>
      *
      * @param sink The destination sink
@@ -411,10 +424,10 @@ public class FusekiProjector implements StallAwareProjector<Event<Bytes, RdfPayl
         this.currentBatchSizeBytes += event.value().sizeInBytes();
 
         if (commitAfterExternalPatch(event) ||
-            commitWhenBatchingDisabled() ||
-            commitWhenBatchSizeBytesExceeded() ||
-            commitWhenBatchSizeReachedWithoutBufferedEvents() ||
-            commitWhenMaxTransactionDurationExceeded(elapsed)) {
+                commitWhenBatchingDisabled() ||
+                commitWhenBatchSizeBytesExceeded() ||
+                commitWhenBatchSizeReachedWithoutBufferedEvents() ||
+                commitWhenMaxTransactionDurationExceeded(elapsed)) {
             return;
         }
 
@@ -673,13 +686,12 @@ public class FusekiProjector implements StallAwareProjector<Event<Bytes, RdfPayl
     /**
      * Requests that the projector pause at its next safe point (between events).
      * <p>
-     * Non-blocking. The projector will commit any in-flight batch and then block on
-     * {@link #pauseMonitor} until {@link #requestResume()} is called. Use
-     * {@code isAtPausePoint()} or {@code FKS.waitForPause(...)} to wait for the projector to
-     * actually reach the pause point.
+     * Non-blocking. The projector will commit any in-flight batch and then block on {@link #pauseMonitor} until
+     * {@link #requestResume()} is called. Use {@code isAtPausePoint()} or {@code FKS.waitForPause(...)} to wait for the
+     * projector to actually reach the pause point.
      * <p>
-     * Calling this from a thread other than the projector thread is required — the projector
-     * thread itself is the one that observes the flag.
+     * Calling this from a thread other than the projector thread is required — the projector thread itself is the one
+     * that observes the flag.
      */
     public void requestPause() {
         synchronized (pauseMonitor) {
@@ -690,8 +702,8 @@ public class FusekiProjector implements StallAwareProjector<Event<Bytes, RdfPayl
     }
 
     /**
-     * Releases a previously requested pause. The projector resumes processing from where it
-     * was blocked at the pause point. Idempotent — safe to call when not paused.
+     * Releases a previously requested pause. The projector resumes processing from where it was blocked at the pause
+     * point. Idempotent — safe to call when not paused.
      */
     public void requestResume() {
         synchronized (pauseMonitor) {
@@ -702,13 +714,13 @@ public class FusekiProjector implements StallAwareProjector<Event<Bytes, RdfPayl
     }
 
     /**
-     * Called by the projector thread on entry to {@link #project(Event, Sink)},
-     * {@link #stalled(Sink)} and {@link #idle(Sink)}. If a pause has been requested, commits any
-     * in-flight Jena transaction so the dataset is idle, then blocks until resumed.
+     * Called by the projector thread on entry to {@link #project(Event, Sink)}, {@link #stalled(Sink)} and
+     * {@link #idle(Sink)}. If a pause has been requested, commits any in-flight Jena transaction so the dataset is
+     * idle, then blocks until resumed.
      * <p>
-     * {@link #idle(Sink)} is what makes a pause reachable on a quiet topic: events may never
-     * arrive to trigger {@link #project(Event, Sink)}, and {@link #stalled(Sink)} is only called
-     * on the first of a run of consecutive stalls.
+     * {@link #idle(Sink)} is what makes a pause reachable on a quiet topic: events may never arrive to trigger
+     * {@link #project(Event, Sink)}, and {@link #stalled(Sink)} is only called on the first of a run of consecutive
+     * stalls.
      */
     private void awaitResumeIfPaused() {
         if (!this.paused) return;

--- a/jena-kafka-connector/src/main/java/org/apache/jena/kafka/common/FusekiProjector.java
+++ b/jena-kafka-connector/src/main/java/org/apache/jena/kafka/common/FusekiProjector.java
@@ -259,15 +259,6 @@ public class FusekiProjector implements StallAwareProjector<Event<Bytes, RdfPayl
 
             // Decide whether to commit transaction now, or wait to commit later
             commitTransactionIfNeeded(event);
-        } catch (JenaKafkaException e) {
-            // In this scenario something has gone wrong while we were processing the event so our current transaction
-            // may now be polluted with partial changes from this event.  Therefore, we need to abort the transaction
-            // and potentially replay the uncommitted events to ensure their data is not lost.
-            if (!sendToDlq(event, e)) {
-                abort();
-                throw e;
-            }
-            abortAndReplay(sink);
         } catch (RdfPayloadException e) {
             // Note that in this scenario we hadn't started processing the event, we merely failed to deserialise it so
             // we don't have any risk of uncommitted changes that need replaying.  The transaction up to this point was
@@ -279,8 +270,11 @@ public class FusekiProjector implements StallAwareProjector<Event<Bytes, RdfPayl
                 throw new JenaKafkaException("Malformed Kafka event", e);
             }
         } catch (Exception e) {
-            // Any other exception unclear what went wrong/when it went wrong, try to send to the DLQ then abort and
-            // replay for safety
+            // In this scenario something has gone wrong while we were processing the event so our current transaction
+            // may now be polluted with partial changes from this event.  Therefore, we need to abort the transaction
+            // and potentially replay the uncommitted events to ensure their data is not lost.
+            // In the event that this is a non-recoverable error when we try and replay we'll hit it again and it will
+            // be thrown upwards
             if (!sendToDlq(event, e)) {
                 abort();
                 throw e;

--- a/jena-kafka-connector/src/test/java/org/apache/jena/kafka/common/TestFusekiProjector.java
+++ b/jena-kafka-connector/src/test/java/org/apache/jena/kafka/common/TestFusekiProjector.java
@@ -18,7 +18,6 @@ import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.DatasetGraphFactory;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.utils.Bytes;
-import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/jena-kafka-connector/src/test/java/org/apache/jena/kafka/common/TestFusekiProjector.java
+++ b/jena-kafka-connector/src/test/java/org/apache/jena/kafka/common/TestFusekiProjector.java
@@ -34,6 +34,8 @@ import static org.mockito.Mockito.*;
 
 class TestFusekiProjector extends AbstractFusekiProjectorTests {
 
+    protected static final String UNEXPECTED_ERROR = "Unexpected error";
+
     @Test
     void givenNoParameters_whenBuildingProjector_thenNPE() {
         // Given, When and Then
@@ -386,5 +388,67 @@ class TestFusekiProjector extends AbstractFusekiProjectorTests {
 
         // Then
         verifyNoTransactions(dsg);
+    }
+
+    @Test
+    void givenProjectorWithDlq_whenSinkThrowsUnexpectedError_thenGoesToDlq() {
+        // Given
+        KConnectorDesc connector = createTestConnector();
+        EventSource<Bytes, RdfPayload> source = new InMemoryEventSource<>(Collections.emptyList());
+        DatasetGraph dsg = mockDatasetGraph();
+        List<Event<Bytes, RdfPayload>> dlqEvents = new ArrayList<>();
+        FusekiProjector projector = buildProjector(connector, source, dsg, 1, dlqEvents::add);
+        Event<Bytes, RdfPayload> event =
+                new KafkaEvent<>(new ConsumerRecord<>("test", 0, 42L, Bytes.wrap(new byte[0]),
+                                                      RdfPayload.of(TestFusekiSink.createSimpleDatasetPayload())),
+                                 null);
+        Sink<Event<Bytes, RdfPayload>> sink = x -> {
+            throw new IllegalStateException(UNEXPECTED_ERROR);
+        };
+
+        // When
+        projector.project(event, sink);
+
+        // Then
+        Assertions.assertEquals(1, dlqEvents.size());
+    }
+
+    @Test
+    void givenProjectorWithoutDlq_whenSinkThrowsUnexpectedError_thenThrownUpwards() {
+        // Given
+        KConnectorDesc connector = createTestConnector();
+        EventSource<Bytes, RdfPayload> source = new InMemoryEventSource<>(Collections.emptyList());
+        DatasetGraph dsg = mockDatasetGraph();
+        FusekiProjector projector = buildProjector(connector, source, dsg, 1, null);
+        Event<Bytes, RdfPayload> event =
+                new KafkaEvent<>(new ConsumerRecord<>("test", 0, 42L, Bytes.wrap(new byte[0]),
+                                                      RdfPayload.of(TestFusekiSink.createSimpleDatasetPayload())),
+                                 null);
+        Sink<Event<Bytes, RdfPayload>> sink = x -> {
+            throw new IllegalStateException(UNEXPECTED_ERROR);
+        };
+
+        // When and Then
+        Assertions.assertThrowsExactly(IllegalStateException.class, () -> projector.project(event, sink),
+                                       UNEXPECTED_ERROR);
+    }
+
+    @Test
+    void givenProjectorWithDlq_whenSinkThrowsNonRecoverableError_thenThrownUpwards() {
+        // Given
+        KConnectorDesc connector = createTestConnector();
+        EventSource<Bytes, RdfPayload> source = new InMemoryEventSource<>(Collections.emptyList());
+        DatasetGraph dsg = mockDatasetGraph();
+        FusekiProjector projector = buildProjector(connector, source, dsg, 1, NullSink.of());
+        Event<Bytes, RdfPayload> event =
+                new KafkaEvent<>(new ConsumerRecord<>("test", 0, 42L, Bytes.wrap(new byte[0]),
+                                                      RdfPayload.of(TestFusekiSink.createSimpleDatasetPayload())),
+                                 null);
+        Sink<Event<Bytes, RdfPayload>> sink = x -> {
+            throw new Error(UNEXPECTED_ERROR);
+        };
+
+        // When and Then
+        Assertions.assertThrowsExactly(Error.class, () -> projector.project(event, sink), UNEXPECTED_ERROR);
     }
 }

--- a/jena-kafka-connector/src/test/java/org/apache/jena/kafka/common/TestFusekiProjector.java
+++ b/jena-kafka-connector/src/test/java/org/apache/jena/kafka/common/TestFusekiProjector.java
@@ -18,6 +18,7 @@ import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.DatasetGraphFactory;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.utils.Bytes;
+import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -85,7 +86,8 @@ class TestFusekiProjector extends AbstractFusekiProjectorTests {
 
 
     private static Stream<Arguments> badMaxDurations() {
-        return Stream.of(() -> new Object[] { null }, Arguments.of(Duration.ZERO), Arguments.of(Duration.ofMinutes(-10)));
+        return Stream.of(() -> new Object[] { null }, Arguments.of(Duration.ZERO),
+                         Arguments.of(Duration.ofMinutes(-10)));
     }
 
     @ParameterizedTest
@@ -140,20 +142,22 @@ class TestFusekiProjector extends AbstractFusekiProjectorTests {
     }
 
     private static Stream<Arguments> projectionBatchingScenarios() {
-        return Stream.of(Arguments.of(List.<Event<Bytes, RdfPayload>>of(createTestDatasetEvent(), createTestDatasetEvent(),
-                                                                         createTestDatasetEvent()), 1, 3, 3, 3),
-                         Arguments.of(List.<Event<Bytes, RdfPayload>>of(createTestDatasetEvent(), createTestDatasetEvent(),
-                                                                         createTestDatasetEvent()), 10, 3, 1, 1),
-                         Arguments.of(List.<Event<Bytes, RdfPayload>>of(createTestDatasetEvent(), createTestDatasetEvent(),
-                                                                         createTestDatasetEvent()), 3, 3, 1, 1),
-                         Arguments.of(List.<Event<Bytes, RdfPayload>>of(createTestDatasetEvent(), createTestDatasetEvent(),
-                                                                         createTestDatasetEvent()), 100, 3, 1, 1));
+        return Stream.of(
+                Arguments.of(List.<Event<Bytes, RdfPayload>>of(createTestDatasetEvent(), createTestDatasetEvent(),
+                                                               createTestDatasetEvent()), 1, 3, 3, 3),
+                Arguments.of(List.<Event<Bytes, RdfPayload>>of(createTestDatasetEvent(), createTestDatasetEvent(),
+                                                               createTestDatasetEvent()), 10, 3, 1, 1),
+                Arguments.of(List.<Event<Bytes, RdfPayload>>of(createTestDatasetEvent(), createTestDatasetEvent(),
+                                                               createTestDatasetEvent()), 3, 3, 1, 1),
+                Arguments.of(List.<Event<Bytes, RdfPayload>>of(createTestDatasetEvent(), createTestDatasetEvent(),
+                                                               createTestDatasetEvent()), 100, 3, 1, 1));
     }
 
     @ParameterizedTest
     @MethodSource("projectionBatchingScenarios")
     void givenProjector_whenProjectingEvents_thenProjectedUsingExpectedTransactionCount(
-            List<Event<Bytes, RdfPayload>> events, int batchSize, long projectedEventCount, int expectedTransactionCount,
+            List<Event<Bytes, RdfPayload>> events, int batchSize, long projectedEventCount,
+            int expectedTransactionCount,
             int expectedCommitCount) {
         // Given
         KConnectorDesc connector = createTestConnector();
@@ -429,8 +433,9 @@ class TestFusekiProjector extends AbstractFusekiProjectorTests {
         };
 
         // When and Then
-        Assertions.assertThrowsExactly(IllegalStateException.class, () -> projector.project(event, sink),
-                                       UNEXPECTED_ERROR);
+        IllegalStateException exception =
+                Assertions.assertThrowsExactly(IllegalStateException.class, () -> projector.project(event, sink));
+        Assertions.assertEquals(UNEXPECTED_ERROR, exception.getMessage());
     }
 
     @Test
@@ -449,6 +454,7 @@ class TestFusekiProjector extends AbstractFusekiProjectorTests {
         };
 
         // When and Then
-        Assertions.assertThrowsExactly(Error.class, () -> projector.project(event, sink), UNEXPECTED_ERROR);
+        Error error = Assertions.assertThrowsExactly(Error.class, () -> projector.project(event, sink));
+        Assertions.assertEquals(UNEXPECTED_ERROR, error.getMessage());
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <groupId>io.telicent.jena</groupId>
     <artifactId>jena-kafka</artifactId>
     <packaging>pom</packaging>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.3.0-SNAPSHOT</version>
 
     <name>Apache Jena Fuseki-Kafka Connector</name>
     <description>Fuseki Module : Kafka Connector</description>
@@ -59,7 +59,7 @@
         <build.time.xsd>${maven.build.timestamp}</build.time.xsd>
         <java.version>21</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.build.outputTimestamp>2026-08-20T11:39:40Z</project.build.outputTimestamp>
+        <project.build.outputTimestamp>2026-09-09T13:13:32Z</project.build.outputTimestamp>
         <coverage.minimum>0.8</coverage.minimum>
         <test.maxForks>2</test.maxForks>
         <!--


### PR DESCRIPTION
Not all recoverable errors were handled by the DLQ so some recoverable errors could cause the projector to abort prematurely

Adds test coverage for both recoverable and non-recoverable error cases

Also adds new counters to the `FKS` class that are automatically updated as polling threads are launched and detecting as failing.  New `launched()`, `failed()` and `running()` static methods provide direct access to these and they are all exposed as new OpenTelemetry metrics